### PR TITLE
[feat]: [PL-29550]: API support to block Debezium events processing of specific account.  (#46107)

### DIFF
--- a/access-control/contracts/api/src/main/java/io/harness/accesscontrol/admin/api/AccessControlAdminResource.java
+++ b/access-control/contracts/api/src/main/java/io/harness/accesscontrol/admin/api/AccessControlAdminResource.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.accesscontrol.admin.api;
+
+import static io.harness.annotations.dev.HarnessTeam.PL;
+
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.ng.core.dto.ErrorDTO;
+import io.harness.ng.core.dto.FailureDTO;
+import io.harness.security.annotations.InternalApi;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.Valid;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+
+@OwnedBy(PL)
+@Api(value = "/admin", hidden = true)
+@Path("/admin")
+@Produces({"application/json", "application/yaml"})
+@Consumes({"application/json", "application/yaml"})
+@ApiResponses(value =
+    {
+      @ApiResponse(code = 400, response = FailureDTO.class, message = "Bad Request")
+      , @ApiResponse(code = 500, response = ErrorDTO.class, message = "Internal server error")
+    })
+@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Bad Request",
+    content =
+    {
+      @Content(mediaType = "application/json", schema = @Schema(implementation = FailureDTO.class))
+      , @Content(mediaType = "application/yaml", schema = @Schema(implementation = FailureDTO.class))
+    })
+@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "Internal server error",
+    content =
+    {
+      @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorDTO.class))
+      , @Content(mediaType = "application/yaml", schema = @Schema(implementation = ErrorDTO.class))
+    })
+public interface AccessControlAdminResource {
+  @POST
+  @Path("block")
+  @ApiOperation(value = "Blocks processing ACLs for a given account", nickname = "blockAccount", hidden = true)
+  @Operation(operationId = "blockAccount", summary = "Blocks processing ACLs for a given account", hidden = true)
+  @InternalApi
+  Response blockAccount(@Valid BlockAccountDTO blockAccountDTO);
+
+  @POST
+  @Path("unblock")
+  @ApiOperation(value = "Unblocks processing ACLs for a given account", nickname = "unblockAccount", hidden = true)
+  @Operation(operationId = "unblockAccount", summary = "UnBlocks processing ACLs for a given account", hidden = true)
+  @InternalApi
+  Response unblockAccount(@Valid UnblockAccountDTO unblockAccountDTO);
+
+  @GET
+  @Path("blocked")
+  @ApiOperation(value = "Get list of blocked accounts", nickname = "getBlockedAccounts", hidden = true)
+  @Operation(operationId = "getBlockedAccounts", summary = "Get list of blocked accounts", hidden = true)
+  @InternalApi
+  Response getBlockedAccounts();
+}

--- a/access-control/contracts/api/src/main/java/io/harness/accesscontrol/admin/api/BlockAccountDTO.java
+++ b/access-control/contracts/api/src/main/java/io/harness/accesscontrol/admin/api/BlockAccountDTO.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.accesscontrol.admin.api;
+
+import io.harness.annotations.dev.HarnessTeam;
+import io.harness.annotations.dev.OwnedBy;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.annotations.ApiModel;
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@Builder(builderClassName = "Builder")
+@JsonIgnoreProperties(ignoreUnknown = true)
+@ApiModel(value = "BlockAccount")
+@Schema(name = "BlockAccount")
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@OwnedBy(HarnessTeam.PL)
+public class BlockAccountDTO {
+  @NotEmpty @NotNull String accountIdentifier;
+}

--- a/access-control/contracts/api/src/main/java/io/harness/accesscontrol/admin/api/UnblockAccountDTO.java
+++ b/access-control/contracts/api/src/main/java/io/harness/accesscontrol/admin/api/UnblockAccountDTO.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.accesscontrol.admin.api;
+
+import io.harness.annotations.dev.HarnessTeam;
+import io.harness.annotations.dev.OwnedBy;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.annotations.ApiModel;
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@Builder(builderClassName = "Builder")
+@JsonIgnoreProperties(ignoreUnknown = true)
+@ApiModel(value = "UnblockAccount")
+@Schema(name = "UnblockAccount")
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@OwnedBy(HarnessTeam.PL)
+public class UnblockAccountDTO {
+  @NotEmpty @NotNull String accountIdentifier;
+}

--- a/access-control/libs/aggregator/src/main/java/io/harness/aggregator/AccessControlAdminService.java
+++ b/access-control/libs/aggregator/src/main/java/io/harness/aggregator/AccessControlAdminService.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.aggregator;
+
+import static java.lang.Boolean.TRUE;
+
+import io.harness.aggregator.models.BlockedAccount;
+import io.harness.aggregator.repositories.BlockedEntityRepository;
+import io.harness.annotations.dev.HarnessTeam;
+import io.harness.annotations.dev.OwnedBy;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Singleton
+@OwnedBy(HarnessTeam.PL)
+public class AccessControlAdminService {
+  private final BlockedEntityRepository blockedEntityRepository;
+  private final GenerateACLsFromRoleAssignmentsJob generateACLsFromRoleAssignmentsJob;
+  private final ExecutorService executorService;
+
+  private final LoadingCache<String, Boolean> blockedAccountCache;
+
+  @Inject
+  public AccessControlAdminService(BlockedEntityRepository blockedEntityRepository,
+      GenerateACLsFromRoleAssignmentsJob generateACLsFromRoleAssignmentsJob) {
+    this.blockedEntityRepository = blockedEntityRepository;
+    this.generateACLsFromRoleAssignmentsJob = generateACLsFromRoleAssignmentsJob;
+    executorService =
+        Executors.newFixedThreadPool(5, new ThreadFactoryBuilder().setNameFormat("blocked-event-processor-%d").build());
+    blockedAccountCache = Caffeine.newBuilder()
+                              .maximumSize(10000)
+                              .expireAfterWrite(30, TimeUnit.MINUTES)
+                              .build(accountId -> blockedEntityRepository.find(accountId).isPresent());
+  }
+
+  public List<BlockedAccount> getAllBlockedAccounts() {
+    return blockedEntityRepository.findAll();
+  }
+
+  public BlockedAccount block(String accountIdentifier) {
+    Optional<BlockedAccount> existingBlockedAccount = blockedEntityRepository.find(accountIdentifier);
+    if (existingBlockedAccount.isEmpty()) {
+      BlockedAccount blockedAccount =
+          blockedEntityRepository.create(BlockedAccount.builder().accountIdentifier(accountIdentifier).build());
+
+      blockedAccountCache.put(accountIdentifier, true);
+      return blockedAccount;
+    }
+    blockedAccountCache.put(accountIdentifier, true);
+    return existingBlockedAccount.get();
+  }
+
+  public void unblock(String accountIdentifier) {
+    blockedEntityRepository.delete(accountIdentifier);
+
+    blockedAccountCache.invalidate(accountIdentifier);
+    executorService.execute(() -> generateACLsFromRoleAssignmentsJob.migrate(accountIdentifier));
+  }
+
+  public boolean isBlocked(String accountIdentifier) {
+    if (accountIdentifier == null) {
+      return false;
+    }
+    return TRUE.equals(blockedAccountCache.get(accountIdentifier));
+  }
+}

--- a/access-control/libs/aggregator/src/main/java/io/harness/aggregator/GenerateACLsFromRoleAssignmentsJob.java
+++ b/access-control/libs/aggregator/src/main/java/io/harness/aggregator/GenerateACLsFromRoleAssignmentsJob.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.aggregator;
+
+import static io.harness.data.structure.EmptyPredicate.isNotEmpty;
+
+import io.harness.accesscontrol.acl.persistence.ACL;
+import io.harness.accesscontrol.acl.persistence.repositories.ACLRepository;
+import io.harness.accesscontrol.principals.PrincipalType;
+import io.harness.accesscontrol.principals.usergroups.persistence.UserGroupDBO;
+import io.harness.accesscontrol.principals.usergroups.persistence.UserGroupRepository;
+import io.harness.accesscontrol.roleassignments.persistence.RoleAssignmentDBO;
+import io.harness.accesscontrol.roleassignments.persistence.RoleAssignmentDBO.RoleAssignmentDBOKeys;
+import io.harness.aggregator.consumers.ChangeConsumerService;
+import io.harness.annotations.dev.HarnessTeam;
+import io.harness.annotations.dev.OwnedBy;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.inject.name.Named;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.util.CloseableIterator;
+
+@Slf4j
+@Singleton
+@OwnedBy(HarnessTeam.PL)
+public class GenerateACLsFromRoleAssignmentsJob {
+  private final ACLRepository aclRepository;
+  private final ChangeConsumerService changeConsumerService;
+  public static final int BATCH_SIZE = 1000;
+  private MongoTemplate mongoTemplate;
+  private UserGroupRepository userGroupRepository;
+
+  @Inject
+  public GenerateACLsFromRoleAssignmentsJob(@Named(ACL.PRIMARY_COLLECTION) ACLRepository aclRepository,
+      ChangeConsumerService changeConsumerService, MongoTemplate mongoTemplate,
+      UserGroupRepository userGroupRepository) {
+    this.aclRepository = aclRepository;
+    this.changeConsumerService = changeConsumerService;
+    this.mongoTemplate = mongoTemplate;
+    this.userGroupRepository = userGroupRepository;
+  }
+
+  private CloseableIterator<RoleAssignmentDBO> runQueryWithBatch(String scopeIdentifier, int batchSize) {
+    Pattern startsWithScope = Pattern.compile("^" + scopeIdentifier);
+    Criteria criteria = Criteria.where(RoleAssignmentDBOKeys.scopeIdentifier).regex(startsWithScope);
+    Query query = new Query();
+    query.addCriteria(criteria);
+    query.cursorBatchSize(batchSize);
+    return mongoTemplate.stream(query, RoleAssignmentDBO.class);
+  }
+
+  private long upsertACLs(RoleAssignmentDBO roleAssignment) {
+    aclRepository.deleteByRoleAssignmentId(roleAssignment.getId());
+    if (roleAssignment.getPrincipalType() == PrincipalType.USER_GROUP) {
+      long numberOfACLsCreated = 0;
+      Optional<UserGroupDBO> userGroupDBO = userGroupRepository.findByIdentifierAndScopeIdentifier(
+          roleAssignment.getPrincipalIdentifier(), roleAssignment.getScopeIdentifier());
+      if (userGroupDBO.isPresent()) {
+        Set<String> users = userGroupDBO.get().getUsers();
+        if (isNotEmpty(users)) {
+          long offset = 0;
+          while (offset < users.size() + 1) {
+            Set<String> subSetUsers = users.stream().skip(offset).limit(1000).collect(Collectors.toSet());
+            List<ACL> aclsToCreate = changeConsumerService.getAClsForRoleAssignment(roleAssignment, subSetUsers);
+
+            aclsToCreate.addAll(
+                changeConsumerService.getImplicitACLsForRoleAssignment(roleAssignment, subSetUsers, new HashSet<>()));
+            aclRepository.insertAllIgnoringDuplicates(aclsToCreate);
+
+            offset += 1000;
+            numberOfACLsCreated += aclsToCreate.size();
+          }
+        } else {
+          log.info("[CreateACLsFromRoleAssignmentsMigration] No users in usergroup {} in scope {}",
+              roleAssignment.getPrincipalIdentifier(), roleAssignment.getScopeIdentifier());
+        }
+      }
+
+      return numberOfACLsCreated;
+    } else {
+      List<ACL> aclsToCreate = changeConsumerService.getAClsForRoleAssignment(roleAssignment);
+      aclsToCreate.addAll(
+          changeConsumerService.getImplicitACLsForRoleAssignment(roleAssignment, new HashSet<>(), new HashSet<>()));
+      return aclRepository.insertAllIgnoringDuplicates(aclsToCreate);
+    }
+  }
+
+  public void migrate(String accountIdentifier) {
+    String scopeIdentifier = "/ACCOUNT/" + accountIdentifier;
+    log.info("[CreateACLsFromRoleAssignmentsMigration] starting migration....");
+    try (CloseableIterator<RoleAssignmentDBO> iterator = runQueryWithBatch(scopeIdentifier, BATCH_SIZE)) {
+      while (iterator.hasNext()) {
+        RoleAssignmentDBO roleAssignmentDBO = iterator.next();
+        try {
+          log.info(
+              "[CreateACLsFromRoleAssignmentsMigration] Number of ACLs created during for roleAssignment {} is : {}",
+              roleAssignmentDBO.getIdentifier(), upsertACLs(roleAssignmentDBO));
+        } catch (Exception e) {
+          log.info("[CreateACLsFromRoleAssignmentsMigration] Unable to process roleassignment: {} due to exception {}",
+              roleAssignmentDBO.getIdentifier(), e);
+        }
+      }
+    }
+    log.info("[CreateACLsFromRoleAssignmentsMigration] migration successful....");
+  }
+}

--- a/access-control/libs/aggregator/src/main/java/io/harness/aggregator/controllers/AggregatorPrimarySyncController.java
+++ b/access-control/libs/aggregator/src/main/java/io/harness/aggregator/controllers/AggregatorPrimarySyncController.java
@@ -16,6 +16,7 @@ import io.harness.accesscontrol.resources.resourcegroups.persistence.ResourceGro
 import io.harness.accesscontrol.roleassignments.persistence.repositories.RoleAssignmentRepository;
 import io.harness.accesscontrol.roles.persistence.repositories.RoleRepository;
 import io.harness.accesscontrol.scopes.core.ScopeService;
+import io.harness.aggregator.AccessControlAdminService;
 import io.harness.aggregator.AggregatorConfiguration;
 import io.harness.aggregator.consumers.AccessControlDebeziumChangeConsumer;
 import io.harness.aggregator.consumers.ChangeConsumerService;
@@ -49,10 +50,12 @@ public class AggregatorPrimarySyncController extends AggregatorBaseSyncControlle
       AggregatorConfiguration aggregatorConfiguration, PersistentLocker persistentLocker,
       ChangeEventFailureHandler changeEventFailureHandler, ChangeConsumerService changeConsumerService,
       RoleAssignmentCRUDEventHandler roleAssignmentCRUDEventHandler,
-      UserGroupCRUDEventHandler userGroupCRUDEventHandler, ScopeService scopeService) {
+      UserGroupCRUDEventHandler userGroupCRUDEventHandler, ScopeService scopeService,
+      AccessControlAdminService accessControlAdminService) {
     super(primaryAclRepository, roleAssignmentRepository, roleRepository, resourceGroupRepository, userGroupRepository,
         aggregatorConfiguration, persistentLocker, changeEventFailureHandler, AggregatorJobType.PRIMARY,
-        changeConsumerService, roleAssignmentCRUDEventHandler, userGroupCRUDEventHandler, scopeService);
+        changeConsumerService, roleAssignmentCRUDEventHandler, userGroupCRUDEventHandler, scopeService,
+        accessControlAdminService);
   }
 
   @Override

--- a/access-control/libs/aggregator/src/main/java/io/harness/aggregator/controllers/AggregatorSecondarySyncController.java
+++ b/access-control/libs/aggregator/src/main/java/io/harness/aggregator/controllers/AggregatorSecondarySyncController.java
@@ -19,6 +19,7 @@ import io.harness.accesscontrol.resources.resourcegroups.persistence.ResourceGro
 import io.harness.accesscontrol.roleassignments.persistence.repositories.RoleAssignmentRepository;
 import io.harness.accesscontrol.roles.persistence.repositories.RoleRepository;
 import io.harness.accesscontrol.scopes.core.ScopeService;
+import io.harness.aggregator.AccessControlAdminService;
 import io.harness.aggregator.AggregatorConfiguration;
 import io.harness.aggregator.consumers.AccessControlDebeziumChangeConsumer;
 import io.harness.aggregator.consumers.ChangeConsumerService;
@@ -61,10 +62,12 @@ public class AggregatorSecondarySyncController extends AggregatorBaseSyncControl
       ChangeEventFailureHandler changeEventFailureHandler,
       MongoReconciliationOffsetRepository mongoReconciliationOffsetRepository,
       ChangeConsumerService changeConsumerService, RoleAssignmentCRUDEventHandler roleAssignmentCRUDEventHandler,
-      UserGroupCRUDEventHandler userGroupCRUDEventHandler, ScopeService scopeService) {
+      UserGroupCRUDEventHandler userGroupCRUDEventHandler, ScopeService scopeService,
+      AccessControlAdminService accessControlAdminService) {
     super(aclRepository, roleAssignmentRepository, roleRepository, resourceGroupRepository, userGroupRepository,
         aggregatorConfiguration, persistentLocker, changeEventFailureHandler, AggregatorJobType.SECONDARY,
-        changeConsumerService, roleAssignmentCRUDEventHandler, userGroupCRUDEventHandler, scopeService);
+        changeConsumerService, roleAssignmentCRUDEventHandler, userGroupCRUDEventHandler, scopeService,
+        accessControlAdminService);
     this.aggregatorSecondarySyncStateRepository = aggregatorSecondarySyncStateRepository;
     this.aclRepository = aclRepository;
     this.mongoReconciliationOffsetRepository = mongoReconciliationOffsetRepository;

--- a/access-control/libs/aggregator/src/main/java/io/harness/aggregator/models/BlockedAccount.java
+++ b/access-control/libs/aggregator/src/main/java/io/harness/aggregator/models/BlockedAccount.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.aggregator.models;
+
+import static io.harness.ng.DbAliases.ACCESS_CONTROL;
+
+import io.harness.annotations.StoreIn;
+import io.harness.annotations.dev.HarnessTeam;
+import io.harness.annotations.dev.OwnedBy;
+
+import dev.morphia.annotations.Entity;
+import lombok.Builder;
+import lombok.Data;
+import lombok.experimental.FieldNameConstants;
+import org.springframework.data.annotation.TypeAlias;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@OwnedBy(HarnessTeam.PL)
+@Data
+@Builder
+@FieldNameConstants(innerTypeName = "BlockedACLEntityKeys")
+@StoreIn(ACCESS_CONTROL)
+@Entity(value = "blockedAccount", noClassnameStored = true)
+@Document("blockedAccount")
+@TypeAlias("blockedAccount")
+public class BlockedAccount {
+  String accountIdentifier;
+}

--- a/access-control/libs/aggregator/src/main/java/io/harness/aggregator/repositories/BlockedEntityRepository.java
+++ b/access-control/libs/aggregator/src/main/java/io/harness/aggregator/repositories/BlockedEntityRepository.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.aggregator.repositories;
+
+import io.harness.aggregator.models.BlockedAccount;
+import io.harness.aggregator.models.BlockedAccount.BlockedACLEntityKeys;
+import io.harness.annotations.dev.HarnessTeam;
+import io.harness.annotations.dev.OwnedBy;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.inject.name.Named;
+import java.util.List;
+import java.util.Optional;
+import javax.validation.executable.ValidateOnExecution;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+
+@OwnedBy(HarnessTeam.PL)
+@Singleton
+@ValidateOnExecution
+public class BlockedEntityRepository {
+  private final MongoTemplate mongoTemplate;
+
+  @Inject
+  public BlockedEntityRepository(@Named("mongoTemplate") MongoTemplate mongoTemplate) {
+    this.mongoTemplate = mongoTemplate;
+  }
+
+  public BlockedAccount create(BlockedAccount blockedAccount) {
+    return mongoTemplate.save(blockedAccount);
+  }
+
+  public Optional<BlockedAccount> find(String accountIdentifier) {
+    Criteria criteria = Criteria.where(BlockedACLEntityKeys.accountIdentifier).is(accountIdentifier);
+    return Optional.ofNullable(mongoTemplate.findOne(new Query(criteria), BlockedAccount.class));
+  }
+
+  public List<BlockedAccount> findAll() {
+    Criteria criteria = Criteria.where(BlockedACLEntityKeys.accountIdentifier).exists(true);
+    return mongoTemplate.find(new Query(criteria), BlockedAccount.class);
+  }
+
+  public void delete(String accountIdentifier) {
+    Criteria criteria = Criteria.where(BlockedACLEntityKeys.accountIdentifier).is(accountIdentifier);
+    mongoTemplate.remove(new Query(criteria), BlockedAccount.class);
+  }
+}

--- a/access-control/libs/aggregator/src/test/java/io/harness/aggregator/AccessControlAdminServiceTest.java
+++ b/access-control/libs/aggregator/src/test/java/io/harness/aggregator/AccessControlAdminServiceTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.aggregator;
+
+import static io.harness.annotations.dev.HarnessTeam.PL;
+import static io.harness.rule.OwnerRule.ASHISHSANODIA;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Lists.emptyList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.harness.aggregator.models.BlockedAccount;
+import io.harness.aggregator.repositories.BlockedEntityRepository;
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.category.element.UnitTests;
+import io.harness.rule.Owner;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+@OwnedBy(PL)
+public class AccessControlAdminServiceTest {
+  @Mock private BlockedEntityRepository blockedEntityRepository;
+  @Mock private GenerateACLsFromRoleAssignmentsJob generateACLsFromRoleAssignmentsJob;
+  private AccessControlAdminService accessControlAdminService;
+  private String accountIdentifier = "accountIdentifier-1";
+  private LoadingCache<String, Boolean> blockedAccountCache;
+  private Field blockedAccountCacheField;
+
+  @Before
+  public void setup() throws NoSuchFieldException, IllegalAccessException {
+    when(blockedEntityRepository.find(anyString()))
+        .thenReturn(Optional.of(BlockedAccount.builder().accountIdentifier(accountIdentifier).build()));
+    when(blockedEntityRepository.findAll())
+        .thenReturn(List.of(BlockedAccount.builder().accountIdentifier(accountIdentifier).build()));
+    accessControlAdminService =
+        new AccessControlAdminService(blockedEntityRepository, generateACLsFromRoleAssignmentsJob);
+
+    blockedAccountCache = Caffeine.newBuilder()
+                              .maximumSize(10000)
+                              .expireAfterWrite(30, TimeUnit.MINUTES)
+                              .build(accountId -> blockedEntityRepository.find(accountId).isPresent());
+    blockedAccountCacheField = accessControlAdminService.getClass().getDeclaredField("blockedAccountCache");
+    blockedAccountCacheField.setAccessible(true);
+    blockedAccountCacheField.set(accessControlAdminService, blockedAccountCache);
+  }
+
+  @Test
+  @Owner(developers = ASHISHSANODIA)
+  @Category(UnitTests.class)
+  public void testBlockAccount() {
+    when(blockedEntityRepository.find(anyString())).thenReturn(Optional.empty());
+    accessControlAdminService.block(accountIdentifier);
+    verify(blockedEntityRepository, times(1)).create(any(BlockedAccount.class));
+
+    Boolean blocked = blockedAccountCache.get(accountIdentifier);
+    assertThat(blocked).isTrue();
+  }
+
+  @Test
+  @Owner(developers = ASHISHSANODIA)
+  @Category(UnitTests.class)
+  public void testBlockAccountForAlreadyBlockedAccount() {
+    blockedAccountCache.put(accountIdentifier, true);
+
+    accessControlAdminService.block(accountIdentifier);
+
+    verify(blockedEntityRepository, times(0)).create(any(BlockedAccount.class));
+
+    Boolean blocked = blockedAccountCache.get(accountIdentifier);
+    assertThat(blocked).isTrue();
+  }
+
+  @Test
+  @Owner(developers = ASHISHSANODIA)
+  @Category(UnitTests.class)
+  public void testBlockAccountWhereItIsPresentInDBButNotInCache() {
+    blockedAccountCache.put(accountIdentifier, false);
+
+    accessControlAdminService.block(accountIdentifier);
+
+    verify(blockedEntityRepository, times(0)).create(any(BlockedAccount.class));
+
+    Boolean blocked = blockedAccountCache.get(accountIdentifier);
+    assertThat(blocked).isTrue();
+  }
+
+  @Test
+  @Owner(developers = ASHISHSANODIA)
+  @Category(UnitTests.class)
+  public void testUnblockAccount() {
+    when(blockedEntityRepository.find(anyString())).thenReturn(Optional.empty());
+    blockedAccountCache.put(accountIdentifier, true);
+    accessControlAdminService.unblock(accountIdentifier);
+    verify(blockedEntityRepository, times(1)).delete(accountIdentifier);
+
+    Boolean blocked = blockedAccountCache.get(accountIdentifier);
+    assertThat(blocked).isFalse();
+  }
+
+  @Test
+  @Owner(developers = ASHISHSANODIA)
+  @Category(UnitTests.class)
+  public void testUnblockForNonBlockedAccount() {
+    blockedAccountCache.put(accountIdentifier, false);
+
+    when(blockedEntityRepository.find(anyString())).thenReturn(Optional.empty());
+    accessControlAdminService.unblock(accountIdentifier);
+    Boolean blocked = blockedAccountCache.get(accountIdentifier);
+    assertThat(blocked).isFalse();
+
+    accessControlAdminService.unblock(accountIdentifier);
+    verify(blockedEntityRepository, times(2)).delete(accountIdentifier);
+
+    blocked = blockedAccountCache.get(accountIdentifier);
+    assertThat(blocked).isFalse();
+  }
+
+  @Test
+  @Owner(developers = ASHISHSANODIA)
+  @Category(UnitTests.class)
+  public void testGetBlockedAccount() {
+    when(blockedEntityRepository.find(anyString())).thenReturn(Optional.empty());
+
+    boolean blocked = accessControlAdminService.isBlocked(accountIdentifier);
+
+    assertThat(blocked).isFalse();
+  }
+
+  @Test
+  @Owner(developers = ASHISHSANODIA)
+  @Category(UnitTests.class)
+  public void testGetNonBlockedAccount() {
+    boolean blocked = accessControlAdminService.isBlocked(accountIdentifier);
+
+    assertThat(blocked).isTrue();
+  }
+
+  @Test
+  @Owner(developers = ASHISHSANODIA)
+  @Category(UnitTests.class)
+  public void testGetBlockedAccountWithNullValue() {
+    boolean blocked = accessControlAdminService.isBlocked(null);
+
+    assertThat(blocked).isFalse();
+  }
+
+  @Test
+  @Owner(developers = ASHISHSANODIA)
+  @Category(UnitTests.class)
+  public void testGetAllBlockedAccounts() {
+    List<BlockedAccount> allBlockedAccounts = accessControlAdminService.getAllBlockedAccounts();
+
+    assertThat(allBlockedAccounts).isNotEmpty();
+    assertThat(allBlockedAccounts.size()).isEqualTo(1);
+  }
+
+  @Test
+  @Owner(developers = ASHISHSANODIA)
+  @Category(UnitTests.class)
+  public void testGetIfThereIsNoBlockedAccount() {
+    when(blockedEntityRepository.findAll()).thenReturn(emptyList());
+    List<BlockedAccount> allBlockedAccounts = accessControlAdminService.getAllBlockedAccounts();
+
+    assertThat(allBlockedAccounts).isEmpty();
+  }
+}

--- a/access-control/libs/core/src/main/java/io/harness/accesscontrol/AccessControlEntity.java
+++ b/access-control/libs/core/src/main/java/io/harness/accesscontrol/AccessControlEntity.java
@@ -10,5 +10,9 @@ package io.harness.accesscontrol;
 import io.harness.annotations.dev.HarnessTeam;
 import io.harness.annotations.dev.OwnedBy;
 
+import java.util.Optional;
+
 @OwnedBy(HarnessTeam.PL)
-public interface AccessControlEntity {}
+public interface AccessControlEntity {
+  Optional<String> getAccountId();
+}

--- a/access-control/libs/core/src/main/java/io/harness/accesscontrol/principals/serviceaccounts/persistence/ServiceAccountDBO.java
+++ b/access-control/libs/core/src/main/java/io/harness/accesscontrol/principals/serviceaccounts/persistence/ServiceAccountDBO.java
@@ -7,8 +7,11 @@
 
 package io.harness.accesscontrol.principals.serviceaccounts.persistence;
 
+import static io.harness.accesscontrol.scopes.core.ScopeHelper.getAccountFromScopeIdentifier;
 import static io.harness.annotations.dev.HarnessTeam.PL;
 import static io.harness.ng.DbAliases.ACCESS_CONTROL;
+
+import static java.util.Optional.ofNullable;
 
 import io.harness.accesscontrol.AccessControlEntity;
 import io.harness.accesscontrol.principals.users.persistence.UserDBO.UserDBOKeys;
@@ -22,6 +25,7 @@ import io.harness.mongo.index.MongoIndex;
 import com.google.common.collect.ImmutableList;
 import dev.morphia.annotations.Entity;
 import java.util.List;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -92,5 +96,10 @@ public class ServiceAccountDBO implements PersistentRegularIterable, AccessContr
   @Override
   public String getUuid() {
     return id;
+  }
+
+  @Override
+  public Optional<String> getAccountId() {
+    return ofNullable(getAccountFromScopeIdentifier(scopeIdentifier));
   }
 }

--- a/access-control/libs/core/src/main/java/io/harness/accesscontrol/principals/usergroups/persistence/UserGroupDBO.java
+++ b/access-control/libs/core/src/main/java/io/harness/accesscontrol/principals/usergroups/persistence/UserGroupDBO.java
@@ -7,8 +7,11 @@
 
 package io.harness.accesscontrol.principals.usergroups.persistence;
 
+import static io.harness.accesscontrol.scopes.core.ScopeHelper.getAccountFromScopeIdentifier;
 import static io.harness.annotations.dev.HarnessTeam.PL;
 import static io.harness.ng.DbAliases.ACCESS_CONTROL;
+
+import static java.util.Optional.ofNullable;
 
 import io.harness.accesscontrol.AccessControlEntity;
 import io.harness.annotations.StoreIn;
@@ -23,6 +26,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ImmutableList;
 import dev.morphia.annotations.Entity;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -98,5 +102,10 @@ public class UserGroupDBO implements PersistentRegularIterable, AccessControlEnt
   @JsonIgnore
   public String getUuid() {
     return id;
+  }
+
+  @Override
+  public Optional<String> getAccountId() {
+    return ofNullable(getAccountFromScopeIdentifier(scopeIdentifier));
   }
 }

--- a/access-control/libs/core/src/main/java/io/harness/accesscontrol/principals/users/persistence/UserDBO.java
+++ b/access-control/libs/core/src/main/java/io/harness/accesscontrol/principals/users/persistence/UserDBO.java
@@ -7,8 +7,11 @@
 
 package io.harness.accesscontrol.principals.users.persistence;
 
+import static io.harness.accesscontrol.scopes.core.ScopeHelper.getAccountFromScopeIdentifier;
 import static io.harness.annotations.dev.HarnessTeam.PL;
 import static io.harness.ng.DbAliases.ACCESS_CONTROL;
+
+import static java.util.Optional.ofNullable;
 
 import io.harness.accesscontrol.AccessControlEntity;
 import io.harness.annotations.StoreIn;
@@ -22,6 +25,7 @@ import io.harness.mongo.index.MongoIndex;
 import com.google.common.collect.ImmutableList;
 import dev.morphia.annotations.Entity;
 import java.util.List;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -94,5 +98,10 @@ public class UserDBO implements PersistentRegularIterable, AccessControlEntity {
   @Override
   public String getUuid() {
     return id;
+  }
+
+  @Override
+  public Optional<String> getAccountId() {
+    return ofNullable(getAccountFromScopeIdentifier(scopeIdentifier));
   }
 }

--- a/access-control/libs/core/src/main/java/io/harness/accesscontrol/resources/resourcegroups/persistence/ResourceGroupDBO.java
+++ b/access-control/libs/core/src/main/java/io/harness/accesscontrol/resources/resourcegroups/persistence/ResourceGroupDBO.java
@@ -7,7 +7,10 @@
 
 package io.harness.accesscontrol.resources.resourcegroups.persistence;
 
+import static io.harness.accesscontrol.scopes.core.ScopeHelper.getAccountFromScopeIdentifier;
 import static io.harness.ng.DbAliases.ACCESS_CONTROL;
+
+import static java.util.Optional.ofNullable;
 
 import io.harness.accesscontrol.AccessControlEntity;
 import io.harness.accesscontrol.resources.resourcegroups.ResourceSelector;
@@ -24,6 +27,7 @@ import io.harness.mongo.index.MongoIndex;
 import com.google.common.collect.ImmutableList;
 import dev.morphia.annotations.Entity;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -106,5 +110,10 @@ public class ResourceGroupDBO implements PersistentRegularIterable, AccessContro
   @Override
   public String getUuid() {
     return id;
+  }
+
+  @Override
+  public Optional<String> getAccountId() {
+    return ofNullable(getAccountFromScopeIdentifier(scopeIdentifier));
   }
 }

--- a/access-control/libs/core/src/main/java/io/harness/accesscontrol/roleassignments/persistence/RoleAssignmentDBO.java
+++ b/access-control/libs/core/src/main/java/io/harness/accesscontrol/roleassignments/persistence/RoleAssignmentDBO.java
@@ -7,8 +7,11 @@
 
 package io.harness.accesscontrol.roleassignments.persistence;
 
+import static io.harness.accesscontrol.scopes.core.ScopeHelper.getAccountFromScopeIdentifier;
 import static io.harness.annotations.dev.HarnessTeam.PL;
 import static io.harness.ng.DbAliases.ACCESS_CONTROL;
+
+import static java.util.Optional.ofNullable;
 
 import io.harness.accesscontrol.AccessControlEntity;
 import io.harness.accesscontrol.principals.PrincipalType;
@@ -23,6 +26,7 @@ import io.harness.persistence.PersistentEntity;
 import com.google.common.collect.ImmutableList;
 import dev.morphia.annotations.Entity;
 import java.util.List;
+import java.util.Optional;
 import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -148,5 +152,10 @@ public class RoleAssignmentDBO implements PersistentEntity, AccessControlEntity 
                  .field(RoleAssignmentDBOKeys.scopeIdentifier)
                  .build())
         .build();
+  }
+
+  @Override
+  public Optional<String> getAccountId() {
+    return ofNullable(getAccountFromScopeIdentifier(scopeIdentifier));
   }
 }

--- a/access-control/libs/core/src/main/java/io/harness/accesscontrol/roles/persistence/RoleDBO.java
+++ b/access-control/libs/core/src/main/java/io/harness/accesscontrol/roles/persistence/RoleDBO.java
@@ -7,7 +7,10 @@
 
 package io.harness.accesscontrol.roles.persistence;
 
+import static io.harness.accesscontrol.scopes.core.ScopeHelper.getAccountFromScopeIdentifier;
 import static io.harness.ng.DbAliases.ACCESS_CONTROL;
+
+import static java.util.Optional.ofNullable;
 
 import io.harness.accesscontrol.AccessControlEntity;
 import io.harness.annotations.StoreIn;
@@ -24,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 import dev.morphia.annotations.Entity;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -84,5 +88,10 @@ public class RoleDBO implements PersistentEntity, AccessControlEntity {
                  .field(RoleDBOKeys.scopeIdentifier)
                  .build())
         .build();
+  }
+
+  @Override
+  public Optional<String> getAccountId() {
+    return ofNullable(getAccountFromScopeIdentifier(scopeIdentifier));
   }
 }

--- a/access-control/libs/core/src/main/java/io/harness/accesscontrol/scopes/core/ScopeHelper.java
+++ b/access-control/libs/core/src/main/java/io/harness/accesscontrol/scopes/core/ScopeHelper.java
@@ -7,10 +7,13 @@
 
 package io.harness.accesscontrol.scopes.core;
 
+import static io.harness.accesscontrol.scopes.core.Scope.PATH_DELIMITER;
 import static io.harness.annotations.dev.HarnessTeam.PL;
 
 import io.harness.annotations.dev.OwnedBy;
 
+import java.util.Arrays;
+import java.util.List;
 import javax.validation.constraints.NotNull;
 import javax.validation.executable.ValidateOnExecution;
 import lombok.experimental.UtilityClass;
@@ -32,5 +35,25 @@ public class ScopeHelper {
       currentScope = currentScope.getParentScope();
     }
     return null;
+  }
+
+  /*
+  It expects scope identifier parameter in either of below format
+  "/ACCOUNT/<account-id>"
+  "/ACCOUNT/<account-id>/ORGANIZATION/<org-id>"
+  "/ACCOUNT/<account-id>/ORGANIZATION/<org-id>/PROJECT/<project-id>"
+  and splits it based on '/' and returns <account-id> from it.
+
+  If input parameter is null OR do not have correct format it returns null.
+   */
+  public static String getAccountFromScopeIdentifier(String scopeIdentifier) {
+    if (scopeIdentifier == null) {
+      return null;
+    }
+    List<String> scopeIdentifierElements = Arrays.asList(scopeIdentifier.split(PATH_DELIMITER));
+    if (scopeIdentifierElements.size() < 3) {
+      return null;
+    }
+    return scopeIdentifierElements.get(2);
   }
 }

--- a/access-control/libs/core/src/main/java/io/harness/accesscontrol/scopes/core/persistence/ScopeDBO.java
+++ b/access-control/libs/core/src/main/java/io/harness/accesscontrol/scopes/core/persistence/ScopeDBO.java
@@ -10,6 +10,8 @@ package io.harness.accesscontrol.scopes.core.persistence;
 import static io.harness.annotations.dev.HarnessTeam.PL;
 import static io.harness.ng.DbAliases.ACCESS_CONTROL;
 
+import static java.util.Optional.empty;
+
 import io.harness.accesscontrol.AccessControlEntity;
 import io.harness.annotations.StoreIn;
 import io.harness.annotations.dev.OwnedBy;
@@ -19,6 +21,7 @@ import io.harness.mongo.index.FdIndex;
 import io.harness.mongo.index.FdUniqueIndex;
 
 import dev.morphia.annotations.Entity;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -77,5 +80,10 @@ public class ScopeDBO implements PersistentRegularIterable, AccessControlEntity 
   @Override
   public String getUuid() {
     return id;
+  }
+
+  @Override
+  public Optional<String> getAccountId() {
+    return empty();
   }
 }

--- a/access-control/service/src/main/java/io/harness/accesscontrol/AccessControlConfiguration.java
+++ b/access-control/service/src/main/java/io/harness/accesscontrol/AccessControlConfiguration.java
@@ -85,6 +85,7 @@ public class AccessControlConfiguration extends Configuration {
   public static final String ACL_PACKAGE = "io.harness.accesscontrol.acl.api";
   public static final String ACCESSCONTROL_PREFERENCE_PACKAGE = "io.harness.accesscontrol.preference.api";
   public static final String AGGREGATOR_PACKAGE = "io.harness.accesscontrol.aggregator.api";
+  public static final String ADMIN_PACKAGE = "io.harness.accesscontrol.admin.api";
   public static final String HEALTH_PACKAGE = "io.harness.accesscontrol.health";
   public static final String ENFORCEMENT_PACKAGE = "io.harness.enforcement.client.resources";
   public static final String ACCESSCONTROL_SERVER_STUB = "io.harness.spec.server.accesscontrol.v1";
@@ -142,7 +143,7 @@ public class AccessControlConfiguration extends Configuration {
         .filter(clazz
             -> StringUtils.startsWithAny(clazz.getPackage().getName(), PERMISSION_PACKAGE, ROLES_PACKAGE,
                 ROLE_ASSIGNMENTS_PACKAGE, ACL_PACKAGE, ACCESSCONTROL_PREFERENCE_PACKAGE, AGGREGATOR_PACKAGE,
-                HEALTH_PACKAGE, ENFORCEMENT_PACKAGE, ACCESSCONTROL_SERVER_STUB))
+                ADMIN_PACKAGE, HEALTH_PACKAGE, ENFORCEMENT_PACKAGE, ACCESSCONTROL_SERVER_STUB))
         .filter(clazz -> clazz.isInterface() || EmptyPredicate.isEmpty(clazz.getInterfaces()))
         .collect(Collectors.toSet());
   }

--- a/access-control/service/src/main/java/io/harness/accesscontrol/AccessControlModule.java
+++ b/access-control/service/src/main/java/io/harness/accesscontrol/AccessControlModule.java
@@ -31,6 +31,8 @@ import io.harness.accesscontrol.acl.ResourceAttributeProvider;
 import io.harness.accesscontrol.acl.api.ACLResource;
 import io.harness.accesscontrol.acl.api.ACLResourceImpl;
 import io.harness.accesscontrol.acl.api.ResourceAttributeProviderImpl;
+import io.harness.accesscontrol.admin.api.AccessControlAdminResource;
+import io.harness.accesscontrol.admin.api.AccessControlAdminResourceImpl;
 import io.harness.accesscontrol.aggregator.api.AggregatorResource;
 import io.harness.accesscontrol.aggregator.api.AggregatorResourceImpl;
 import io.harness.accesscontrol.aggregator.consumers.AccessControlChangeEventFailureHandler;
@@ -395,6 +397,7 @@ public class AccessControlModule extends AbstractModule {
 
     bind(ACLResource.class).to(ACLResourceImpl.class);
     bind(AggregatorResource.class).to(AggregatorResourceImpl.class);
+    bind(AccessControlAdminResource.class).to(AccessControlAdminResourceImpl.class);
     bind(HealthResource.class).to(HealthResourceImpl.class);
     bind(PermissionResource.class).to(PermissionResourceImpl.class);
     bind(AccessControlPreferenceResource.class).to(AccessControlPreferenceResourceImpl.class);

--- a/access-control/service/src/main/java/io/harness/accesscontrol/admin/api/AccessControlAdminResourceImpl.java
+++ b/access-control/service/src/main/java/io/harness/accesscontrol/admin/api/AccessControlAdminResourceImpl.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.accesscontrol.admin.api;
+
+import io.harness.aggregator.AccessControlAdminService;
+import io.harness.aggregator.models.BlockedAccount;
+import io.harness.annotations.dev.HarnessTeam;
+import io.harness.annotations.dev.OwnedBy;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.ws.rs.core.Response;
+import lombok.extern.slf4j.Slf4j;
+
+@Singleton
+@Slf4j
+@OwnedBy(HarnessTeam.PL)
+public class AccessControlAdminResourceImpl implements AccessControlAdminResource {
+  private AccessControlAdminService accessControlAdminService;
+
+  @Inject
+  public AccessControlAdminResourceImpl(AccessControlAdminService accessControlAdminService) {
+    this.accessControlAdminService = accessControlAdminService;
+  }
+
+  @Override
+  public Response blockAccount(BlockAccountDTO blockAccountDTO) {
+    accessControlAdminService.block(blockAccountDTO.getAccountIdentifier());
+    return Response.accepted().build();
+  }
+
+  @Override
+  public Response unblockAccount(UnblockAccountDTO unblockAccountDTO) {
+    accessControlAdminService.unblock(unblockAccountDTO.getAccountIdentifier());
+    return Response.accepted().build();
+  }
+
+  @Override
+  public Response getBlockedAccounts() {
+    List<BlockedAccount> blockedACLEntities = accessControlAdminService.getAllBlockedAccounts();
+    List<BlockAccountDTO> blockAccountDTOS =
+        blockedACLEntities.stream()
+            .map(blockedAccount
+                -> BlockAccountDTO.builder().accountIdentifier(blockedAccount.getAccountIdentifier()).build())
+            .collect(Collectors.toList());
+    return Response.ok().entity(blockAccountDTOS).build();
+  }
+}

--- a/access-control/service/src/main/java/io/harness/accesscontrol/roleassignments/privileged/persistence/PrivilegedRoleAssignmentDBO.java
+++ b/access-control/service/src/main/java/io/harness/accesscontrol/roleassignments/privileged/persistence/PrivilegedRoleAssignmentDBO.java
@@ -10,6 +10,8 @@ package io.harness.accesscontrol.roleassignments.privileged.persistence;
 import static io.harness.accesscontrol.roleassignments.privileged.persistence.PrivilegedRoleAssignmentDBO.COLLECTION_NAME;
 import static io.harness.ng.DbAliases.ACCESS_CONTROL;
 
+import static java.util.Optional.empty;
+
 import io.harness.accesscontrol.AccessControlEntity;
 import io.harness.accesscontrol.principals.PrincipalType;
 import io.harness.annotations.StoreIn;
@@ -23,6 +25,7 @@ import io.harness.persistence.PersistentEntity;
 import com.google.common.collect.ImmutableList;
 import dev.morphia.annotations.Entity;
 import java.util.List;
+import java.util.Optional;
 import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -94,5 +97,10 @@ public class PrivilegedRoleAssignmentDBO implements PersistentEntity, AccessCont
                  .field(PrivilegedRoleAssignmentDBOKeys.principalIdentifier)
                  .build())
         .build();
+  }
+
+  @Override
+  public Optional<String> getAccountId() {
+    return empty();
   }
 }

--- a/access-control/service/src/main/java/io/harness/accesscontrol/support/persistence/SupportPreferenceDBO.java
+++ b/access-control/service/src/main/java/io/harness/accesscontrol/support/persistence/SupportPreferenceDBO.java
@@ -9,6 +9,8 @@ package io.harness.accesscontrol.support.persistence;
 
 import static io.harness.ng.DbAliases.ACCESS_CONTROL;
 
+import static java.util.Optional.of;
+
 import io.harness.accesscontrol.AccessControlEntity;
 import io.harness.annotations.StoreIn;
 import io.harness.annotations.dev.HarnessTeam;
@@ -19,6 +21,7 @@ import io.harness.mongo.index.FdIndex;
 import io.harness.mongo.index.FdUniqueIndex;
 
 import dev.morphia.annotations.Entity;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -78,5 +81,10 @@ public class SupportPreferenceDBO implements PersistentRegularIterable, AccessCo
   @Override
   public String getUuid() {
     return id;
+  }
+
+  @Override
+  public Optional<String> getAccountId() {
+    return of(accountIdentifier);
   }
 }


### PR DESCRIPTION
* [fix]: [PL-29550]: Adds blockedACLEventsCache configuration in access control

* [fix]: [PL-29550]: Adds ACL admin resource, impl and service

* [fix]: [PL-29550]: Adds ACL admin resource impl and repositories

* [fix]: [PL-29550]: Adds ACL admin resource service and using it

* [fix]: [PL-29550]: Renames api path for admin resource change events api

* [fix]: [PL-29550]: Registers admin resource change events api in access control module

* [fix]: [PL-29550]: Adds migration job to run before unblocking change events

* [fix]: [PL-29550]: Refactors field variable name

* [fix]: [PL-29550]: Minor refactoring

* [fix]: [PL-29550]: Refactors access control admin service

* [fix]: [PL-29550]: Refactors AccessControlEntity to provide account identifier

* [fix]: [PL-29550]: Removes should refactor method from change consumer impls

* [fix]: [PL-29550]: Refactors dto and db objects

* [fix]: [PL-29550]: Adds unit tests for access control admin service

* [fix]: [PL-29550]: Fixing check style issues

* [feat]: [PL-32362]: Handles null scope identifier while geting account id from it

* [fix]: [PL-29550]: fixing scope identifier value in migration job and minor refactoring

* [fix]: [PL-29550]: Changes as per review comment

* [fix]: [PL-29550]: Makes account identifier in request mandatory

* [fix]: [PL-29550]: Updated api description as per review comment

* [fix]: [PL-29550]: Fixing isBlocked method as per review comment

* [fix]: [PL-29550]: Fixing getAccountId overrides in Acces control enitity implementations

* [fix]: [PL-29550]: Renames entities as per review comment

* [fix]: [PL-29550]: Moves logic to build scope from account inside migration job

* [fix]: [PL-29550]: Refactors based on review comment

* [fix]: [PL-29550]: Introducing caffiene in memory cache

* [fix]: [PL-29550]: Minor refactoring

* [fix]: [PL-29550]: Removes distributed cache using in memory cache instead

* [fix]: [PL-29550]: Removes unused method from service

* [fix]: [PL-29550]: Refactoring getAccount method to return optional

* [fix]: [PL-29550]: Removes unused service reference from change consumer impls

* [fix]: [PL-29550]: Adds not null annotation to request dto field

* [fix]: [PL-29550]: Fixing Unnecessary stubbings issue in service test

* [fix]: [PL-29550]: Updates api description and thread pool size