### PR TITLE
fix: [PLG-2215]: Set selfService to true for new CI trial licenses (#46921)

### DIFF
--- a/930-ng-license-manager/src/main/java/io/harness/licensing/interfaces/clients/local/CILocalClient.java
+++ b/930-ng-license-manager/src/main/java/io/harness/licensing/interfaces/clients/local/CILocalClient.java
@@ -30,8 +30,11 @@ public class CILocalClient implements CIModuleLicenseClient {
     long expiryTime = Instant.now().plus(TRIAL_DURATION, ChronoUnit.DAYS).toEpochMilli();
     long currentTime = Instant.now().toEpochMilli();
 
-    CIModuleLicenseDTOBuilder<?, ?> builder =
-        CIModuleLicenseDTO.builder().startTime(currentTime).expiryTime(expiryTime).status(LicenseStatus.ACTIVE);
+    CIModuleLicenseDTOBuilder<?, ?> builder = CIModuleLicenseDTO.builder()
+                                                  .startTime(currentTime)
+                                                  .expiryTime(expiryTime)
+                                                  .status(LicenseStatus.ACTIVE)
+                                                  .selfService(true);
 
     switch (edition) {
       case ENTERPRISE:

--- a/930-ng-license-manager/src/test/java/io/harness/licensing/interfaces/ModuleLicenseInterfaceImplTest.java
+++ b/930-ng-license-manager/src/test/java/io/harness/licensing/interfaces/ModuleLicenseInterfaceImplTest.java
@@ -74,6 +74,7 @@ public class ModuleLicenseInterfaceImplTest extends CategoryTest {
                                        .status(LicenseStatus.ACTIVE)
                                        .startTime(0)
                                        .expiryTime(0)
+                                       .selfService(true)
                                        .build();
     CIModuleLicenseDTO dto = (CIModuleLicenseDTO) moduleLicenseInterface.generateTrialLicense(
         Edition.ENTERPRISE, ACCOUNT_IDENTIFIER, ModuleType.CI);
@@ -96,6 +97,7 @@ public class ModuleLicenseInterfaceImplTest extends CategoryTest {
                                        .status(LicenseStatus.ACTIVE)
                                        .startTime(0)
                                        .expiryTime(0)
+                                       .selfService(true)
                                        .build();
     CIModuleLicenseDTO dto = (CIModuleLicenseDTO) moduleLicenseInterface.generateTrialLicense(
         Edition.TEAM, ACCOUNT_IDENTIFIER, ModuleType.CI);
@@ -117,6 +119,7 @@ public class ModuleLicenseInterfaceImplTest extends CategoryTest {
                                        .edition(Edition.FREE)
                                        .startTime(0)
                                        .expiryTime(Long.MAX_VALUE)
+                                       .selfService(true)
                                        .build();
     CIModuleLicenseDTO dto =
         (CIModuleLicenseDTO) moduleLicenseInterface.generateFreeLicense(ACCOUNT_IDENTIFIER, ModuleType.CI);


### PR DESCRIPTION
* [PLG-2215]: Set selfService to true when creating a CI trial license.

* [PLG-2215]: Fix tests for CI trial licenses