### PR TITLE
fix:[CDS-53549]: Using the step timeout as the delegate task timeout (#46914)

### DIFF
--- a/400-rest/src/main/java/software/wings/sm/states/GcbState.java
+++ b/400-rest/src/main/java/software/wings/sm/states/GcbState.java
@@ -271,7 +271,7 @@ public class GcbState extends State implements SweepingOutputStateMixin {
                   .async(true)
                   .taskType(GCB.name())
                   .parameters(parameters)
-                  .timeout(DEFAULT_ASYNC_CALL_TIMEOUT)
+                  .timeout(getTimeoutMillis())
                   .build())
         .setupAbstraction(Cd1SetupFields.ENV_ID_FIELD, envId)
         .setupAbstraction(Cd1SetupFields.ENV_TYPE_FIELD, context.getEnvType())


### PR DESCRIPTION
The timeout value set in the step has not been using to determine the delegate task timeout causing to workflow execution abort when the build step take more than 10 minutes to complete.