### PR TITLE
feat: [PL-32231]: Supporting sort delegateGroups by name. (#46821)

### DIFF
--- a/400-rest/src/test/java/software/wings/resources/DelegateSetupResourceTest.java
+++ b/400-rest/src/test/java/software/wings/resources/DelegateSetupResourceTest.java
@@ -174,8 +174,8 @@ public class DelegateSetupResourceTest extends CategoryTest {
   @Category(UnitTests.class)
   public void listV2ShouldReturnDelegates() {
     DelegateGroupDetails delegateGroupDetails = DelegateGroupDetails.builder().groupName("group name").build();
-    when(delegateSetupService.listDelegateGroupDetailsV2(
-             eq(ACCOUNT_ID), eq("orgId"), eq("projectId"), any(), any(), any(DelegateFilterPropertiesDTO.class)))
+    when(delegateSetupService.listDelegateGroupDetailsV2(eq(ACCOUNT_ID), eq("orgId"), eq("projectId"), any(), any(),
+             any(DelegateFilterPropertiesDTO.class), any(io.harness.ng.beans.PageRequest.class)))
         .thenReturn(DelegateGroupListing.builder().delegateGroupDetails(Lists.list(delegateGroupDetails)).build());
     RestResponse<DelegateGroupListing> restResponse =
         RESOURCES.client()
@@ -185,8 +185,9 @@ public class DelegateSetupResourceTest extends CategoryTest {
                 new GenericType<RestResponse<DelegateGroupListing>>() {});
 
     verify(delegateSetupService, atLeastOnce())
-        .listDelegateGroupDetailsV2(
-            ACCOUNT_ID, "orgId", "projectId", null, null, DelegateFilterPropertiesDTO.builder().build());
+        .listDelegateGroupDetailsV2(ACCOUNT_ID, "orgId", "projectId", null, null,
+            DelegateFilterPropertiesDTO.builder().build(),
+            io.harness.ng.beans.PageRequest.builder().pageSize(50).sortOrders(Collections.emptyList()).build());
     assertThat(restResponse.getResource().getDelegateGroupDetails()).isNotEmpty();
     assertThat(restResponse.getResource().getDelegateGroupDetails().get(0).getGroupName()).isEqualTo("group name");
   }

--- a/420-delegate-service/src/main/java/io/harness/delegate/resources/DelegateSetupResourceV2.java
+++ b/420-delegate-service/src/main/java/io/harness/delegate/resources/DelegateSetupResourceV2.java
@@ -18,12 +18,12 @@ import io.harness.accesscontrol.acl.api.ResourceScope;
 import io.harness.accesscontrol.clients.AccessControlClient;
 import io.harness.annotations.dev.HarnessTeam;
 import io.harness.annotations.dev.OwnedBy;
-import io.harness.beans.PageRequest;
 import io.harness.delegate.beans.DelegateGroupDetails;
 import io.harness.delegate.beans.DelegateGroupListing;
 import io.harness.delegate.filter.DelegateFilterPropertiesDTO;
 import io.harness.logging.AccountLogContext;
 import io.harness.logging.AutoLogContext;
+import io.harness.ng.beans.PageRequest;
 import io.harness.ng.core.dto.ErrorDTO;
 import io.harness.ng.core.dto.FailureDTO;
 import io.harness.rest.RestResponse;
@@ -120,14 +120,13 @@ public class DelegateSetupResourceV2 {
       @QueryParam(NGResourceFilterConstants.FILTER_KEY) String filterIdentifier,
       @QueryParam(NGResourceFilterConstants.SEARCH_TERM_KEY) String searchTerm,
       @Body @RequestBody(description = "Details of the Delegate filter properties to be applied")
-      DelegateFilterPropertiesDTO delegateFilterPropertiesDTO,
-      @BeanParam PageRequest<DelegateGroupDetails> pageRequest) {
+      DelegateFilterPropertiesDTO delegateFilterPropertiesDTO, @BeanParam PageRequest pageRequest) {
     accessControlClient.checkForAccessOrThrow(ResourceScope.of(accountId, orgId, projectId),
         Resource.of(DELEGATE_RESOURCE_TYPE, null), DELEGATE_VIEW_PERMISSION);
 
     try (AutoLogContext ignore1 = new AccountLogContext(accountId, OVERRIDE_ERROR)) {
       return new RestResponse<>(delegateSetupService.listDelegateGroupDetailsV2(
-          accountId, orgId, projectId, filterIdentifier, searchTerm, delegateFilterPropertiesDTO));
+          accountId, orgId, projectId, filterIdentifier, searchTerm, delegateFilterPropertiesDTO, pageRequest));
     }
   }
 

--- a/420-delegate-service/src/main/java/io/harness/service/intfc/DelegateSetupService.java
+++ b/420-delegate-service/src/main/java/io/harness/service/intfc/DelegateSetupService.java
@@ -18,6 +18,7 @@ import io.harness.delegate.beans.DelegateGroupDetails;
 import io.harness.delegate.beans.DelegateGroupListing;
 import io.harness.delegate.beans.DelegateGroupTags;
 import io.harness.delegate.filter.DelegateFilterPropertiesDTO;
+import io.harness.ng.beans.PageRequest;
 
 import software.wings.beans.SelectorType;
 
@@ -57,7 +58,8 @@ public interface DelegateSetupService {
       String accountId, String orgId, String projectId, String identifier, DelegateGroupDetails delegateGroupDetails);
 
   DelegateGroupListing listDelegateGroupDetailsV2(String accountId, String orgId, String projectId,
-      String filterIdentifier, String searchTerm, DelegateFilterPropertiesDTO delegateFilterPropertiesDTO);
+      String filterIdentifier, String searchTerm, DelegateFilterPropertiesDTO delegateFilterPropertiesDTO,
+      PageRequest pageRequest);
 
   DelegateGroupListing listDelegateGroupDetails(
       String accountId, String orgId, String projectId, String delegateTokenName);

--- a/420-delegate-service/src/test/java/io/harness/service/DelegateSetupServiceTest.java
+++ b/420-delegate-service/src/test/java/io/harness/service/DelegateSetupServiceTest.java
@@ -27,6 +27,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 import io.harness.DelegateServiceTestBase;
 import io.harness.annotations.dev.HarnessTeam;
 import io.harness.annotations.dev.OwnedBy;
+import io.harness.beans.SortOrder;
 import io.harness.category.element.UnitTests;
 import io.harness.delegate.beans.AutoUpgrade;
 import io.harness.delegate.beans.Delegate;
@@ -50,6 +51,7 @@ import io.harness.delegate.filter.DelegateFilterPropertiesDTO;
 import io.harness.delegate.filter.DelegateInstanceConnectivityStatus;
 import io.harness.delegate.utils.DelegateEntityOwnerHelper;
 import io.harness.exception.InvalidRequestException;
+import io.harness.ng.beans.PageRequest;
 import io.harness.persistence.HPersistence;
 import io.harness.rule.Owner;
 import io.harness.service.impl.DelegateSetupServiceImpl;
@@ -269,8 +271,8 @@ public class DelegateSetupServiceTest extends DelegateServiceTestBase {
   public void listV2ShouldReturnDelegateGroups() {
     prepareInitialData();
 
-    DelegateGroupListing delegateGroupListing = delegateSetupService.listDelegateGroupDetailsV2(
-        TEST_ACCOUNT_ID, null, null, "", "", DelegateFilterPropertiesDTO.builder().build());
+    DelegateGroupListing delegateGroupListing = delegateSetupService.listDelegateGroupDetailsV2(TEST_ACCOUNT_ID, null,
+        null, "", "", DelegateFilterPropertiesDTO.builder().build(), PageRequest.builder().build());
 
     assertThat(delegateGroupListing.getDelegateGroupDetails()).hasSize(3);
     assertThat(delegateGroupListing.getDelegateGroupDetails())
@@ -285,8 +287,8 @@ public class DelegateSetupServiceTest extends DelegateServiceTestBase {
   @Owner(developers = BOJAN)
   @Category(UnitTests.class)
   public void listV2ShouldThrowException() {
-    delegateSetupService.listDelegateGroupDetailsV2(
-        TEST_ACCOUNT_ID, null, null, "filterId", "", DelegateFilterPropertiesDTO.builder().build());
+    delegateSetupService.listDelegateGroupDetailsV2(TEST_ACCOUNT_ID, null, null, "filterId", "",
+        DelegateFilterPropertiesDTO.builder().build(), PageRequest.builder().build());
   }
 
   @Test
@@ -297,8 +299,8 @@ public class DelegateSetupServiceTest extends DelegateServiceTestBase {
 
     DelegateFilterPropertiesDTO filterProperties =
         DelegateFilterPropertiesDTO.builder().delegateGroupIdentifier("ier1").build();
-    DelegateGroupListing delegateGroupListing =
-        delegateSetupService.listDelegateGroupDetailsV2(TEST_ACCOUNT_ID, null, null, "", "", filterProperties);
+    DelegateGroupListing delegateGroupListing = delegateSetupService.listDelegateGroupDetailsV2(
+        TEST_ACCOUNT_ID, null, null, "", "", filterProperties, PageRequest.builder().build());
 
     assertThat(delegateGroupListing.getDelegateGroupDetails()).hasSize(1);
     assertThat(delegateGroupListing.getDelegateGroupDetails())
@@ -318,11 +320,11 @@ public class DelegateSetupServiceTest extends DelegateServiceTestBase {
     DelegateFilterPropertiesDTO filterPropertiesDisconnected =
         DelegateFilterPropertiesDTO.builder().status(DelegateInstanceConnectivityStatus.DISCONNECTED).build();
 
-    DelegateGroupListing delegateGroupListing1 =
-        delegateSetupService.listDelegateGroupDetailsV2(TEST_ACCOUNT_ID, null, null, "", "", filterPropertiesConnected);
+    DelegateGroupListing delegateGroupListing1 = delegateSetupService.listDelegateGroupDetailsV2(
+        TEST_ACCOUNT_ID, null, null, "", "", filterPropertiesConnected, PageRequest.builder().build());
 
     DelegateGroupListing delegateGroupListing2 = delegateSetupService.listDelegateGroupDetailsV2(
-        TEST_ACCOUNT_ID, null, null, "", "", filterPropertiesDisconnected);
+        TEST_ACCOUNT_ID, null, null, "", "", filterPropertiesDisconnected, PageRequest.builder().build());
 
     assertThat(delegateGroupListing1.getDelegateGroupDetails()).hasSize(2);
     assertThat(delegateGroupListing2.getDelegateGroupDetails()).hasSize(0);
@@ -334,8 +336,8 @@ public class DelegateSetupServiceTest extends DelegateServiceTestBase {
   public void listV2ShouldReturnDelegateGroupsFilteredBySearchTerm_Name() {
     prepareInitialData();
 
-    DelegateGroupListing delegateGroupListing = delegateSetupService.listDelegateGroupDetailsV2(
-        TEST_ACCOUNT_ID, null, null, "", "grp1", DelegateFilterPropertiesDTO.builder().build());
+    DelegateGroupListing delegateGroupListing = delegateSetupService.listDelegateGroupDetailsV2(TEST_ACCOUNT_ID, null,
+        null, "", "grp1", DelegateFilterPropertiesDTO.builder().build(), PageRequest.builder().build());
 
     assertThat(delegateGroupListing.getDelegateGroupDetails()).hasSize(1);
     assertThat(delegateGroupListing.getDelegateGroupDetails())
@@ -344,13 +346,44 @@ public class DelegateSetupServiceTest extends DelegateServiceTestBase {
   }
 
   @Test
+  @Owner(developers = BOOPESH)
+  @Category(UnitTests.class)
+  public void listV2ShouldReturnDelegateGroupsBySortOrderName() {
+    prepareInitialData();
+
+    DelegateGroupListing delegateGroupListing = delegateSetupService.listDelegateGroupDetailsV2(TEST_ACCOUNT_ID, null,
+        null, "", "", DelegateFilterPropertiesDTO.builder().build(),
+        PageRequest.builder()
+            .sortOrders(Collections.singletonList(
+                SortOrder.Builder.aSortOrder().withField("name", SortOrder.OrderType.DESC).build()))
+            .build());
+    assertThat(delegateGroupListing.getDelegateGroupDetails()).hasSize(3);
+    assertThat(delegateGroupListing.getDelegateGroupDetails().get(0).getGroupId()).isEqualTo("delegateGroupId4");
+  }
+
+  @Test
+  @Owner(developers = BOOPESH)
+  @Category(UnitTests.class)
+  public void listV2ShouldReturnDelegateGroupsBySortOrderVersion() {
+    prepareInitialData();
+    DelegateGroupListing delegateGroupListing = delegateSetupService.listDelegateGroupDetailsV2(TEST_ACCOUNT_ID, null,
+        null, "", "", DelegateFilterPropertiesDTO.builder().build(),
+        PageRequest.builder()
+            .sortOrders(Collections.singletonList(
+                SortOrder.Builder.aSortOrder().withField("version", SortOrder.OrderType.DESC).build()))
+            .build());
+    assertThat(delegateGroupListing.getDelegateGroupDetails()).hasSize(3);
+    assertThat(delegateGroupListing.getDelegateGroupDetails().get(0).getGroupId()).isEqualTo("delegateGroupId1");
+  }
+
+  @Test
   @Owner(developers = BOJAN)
   @Category(UnitTests.class)
   public void listV2ShouldReturnDelegateGroupsFilteredBySearchTerm_Tags1() {
     prepareInitialData();
 
-    DelegateGroupListing delegateGroupListing = delegateSetupService.listDelegateGroupDetailsV2(
-        TEST_ACCOUNT_ID, null, null, "", "taggroup1", DelegateFilterPropertiesDTO.builder().build());
+    DelegateGroupListing delegateGroupListing = delegateSetupService.listDelegateGroupDetailsV2(TEST_ACCOUNT_ID, null,
+        null, "", "taggroup1", DelegateFilterPropertiesDTO.builder().build(), PageRequest.builder().build());
 
     assertThat(delegateGroupListing.getDelegateGroupDetails()).hasSize(1);
   }
@@ -361,8 +394,8 @@ public class DelegateSetupServiceTest extends DelegateServiceTestBase {
   public void listV2ShouldReturnDelegateGroupsFilteredBySearchTerm_Tags3() {
     prepareInitialData();
 
-    DelegateGroupListing delegateGroupListing = delegateSetupService.listDelegateGroupDetailsV2(
-        TEST_ACCOUNT_ID, null, null, "", "taggroup3", DelegateFilterPropertiesDTO.builder().build());
+    DelegateGroupListing delegateGroupListing = delegateSetupService.listDelegateGroupDetailsV2(TEST_ACCOUNT_ID, null,
+        null, "", "taggroup3", DelegateFilterPropertiesDTO.builder().build(), PageRequest.builder().build());
 
     assertThat(delegateGroupListing.getDelegateGroupDetails()).hasSize(0);
   }
@@ -373,8 +406,8 @@ public class DelegateSetupServiceTest extends DelegateServiceTestBase {
   public void listV2ShouldReturnDelegateGroupsFilteredBySearchTerm_Tags4() {
     prepareInitialData();
 
-    DelegateGroupListing delegateGroupListing = delegateSetupService.listDelegateGroupDetailsV2(
-        TEST_ACCOUNT_ID, null, null, "", "taggroup4", DelegateFilterPropertiesDTO.builder().build());
+    DelegateGroupListing delegateGroupListing = delegateSetupService.listDelegateGroupDetailsV2(TEST_ACCOUNT_ID, null,
+        null, "", "taggroup4", DelegateFilterPropertiesDTO.builder().build(), PageRequest.builder().build());
 
     assertThat(delegateGroupListing.getDelegateGroupDetails()).hasSize(1);
   }
@@ -385,8 +418,8 @@ public class DelegateSetupServiceTest extends DelegateServiceTestBase {
   public void listV2ShouldReturnDelegateGroupsFilteredBySearchTerm_CommonTag() {
     prepareInitialData();
 
-    DelegateGroupListing delegateGroupListing = delegateSetupService.listDelegateGroupDetailsV2(
-        TEST_ACCOUNT_ID, null, null, "", "commonTag", DelegateFilterPropertiesDTO.builder().build());
+    DelegateGroupListing delegateGroupListing = delegateSetupService.listDelegateGroupDetailsV2(TEST_ACCOUNT_ID, null,
+        null, "", "commonTag", DelegateFilterPropertiesDTO.builder().build(), PageRequest.builder().build());
 
     assertThat(delegateGroupListing.getDelegateGroupDetails()).hasSize(1);
     assertThat(delegateGroupListing.getDelegateGroupDetails())


### PR DESCRIPTION
* feat: [PL-32487]: Entity Class for Entity Favourites.

* feat: [PL-32231]: Supporting sort delegateGroups by name.

* Revert "feat: [PL-32487]: Entity Class for Entity Favourites."

This reverts commit 764a33a3fb6313375f7688eaea27400f633e2223.

* feat: [PL-32231]: Supporting sort delegateGroups by name.

* feat: [PL-32231]: Supporting sort delegateGroups by name.

* feat: [PL-32231]: Supporting sort delegateGroups by name.

* feat: [PL-32231]: Supporting sort delegateGroups by name.

* feat: [PL-32231]: Supporting sort delegateGroups by name.