### PR TITLE
[fix]: [PL-28358]: Add DB query improvement to fetch only matching accountId, userGroupId from userInvites collection for updation while unlinking SSO group (#46981)

### DIFF
--- a/400-rest/src/main/java/software/wings/service/impl/UserGroupServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/UserGroupServiceImpl.java
@@ -1092,8 +1092,10 @@ public class UserGroupServiceImpl implements UserGroupService {
   }
 
   private void removeUserGroupFromInvites(String accountId, String userGroupId) {
-    List<UserInvite> invites = userService.getInvitesFromAccountId(accountId);
-    invites.forEach(invite -> invite.getUserGroups().removeIf(x -> x.getUuid().equals(userGroupId)));
+    List<UserInvite> invites = userService.getInvitesFromAccountIdAndUserGroupId(accountId, userGroupId);
+    invites.forEach(invite -> invite.getUserGroups().removeIf(group -> group.getUuid().equals(userGroupId)));
+    log.info(
+        "Removing user group id {} from userInvites for unlink SSO group flow in account {}", userGroupId, accountId);
     wingsPersistence.save(invites);
   }
 

--- a/400-rest/src/main/java/software/wings/service/impl/UserServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/UserServiceImpl.java
@@ -2490,6 +2490,15 @@ public class UserServiceImpl implements UserService {
   }
 
   @Override
+  public List<UserInvite> getInvitesFromAccountIdAndUserGroupId(String accountId, String userGroupId) {
+    Query<UserInvite> userInviteQuery = wingsPersistence.createQuery(UserInvite.class)
+                                            .filter(ACCOUNT_ID_KEY, accountId)
+                                            .field(UserInviteKeys.userGroups)
+                                            .hasThisOne(userGroupId);
+    return userInviteQuery.asList();
+  }
+
+  @Override
   public boolean resetPassword(UserResource.ResetPasswordRequest resetPasswordRequest) {
     String email = resetPasswordRequest.getEmail();
     User user = getUserByEmail(email);

--- a/400-rest/src/main/java/software/wings/service/intfc/UserService.java
+++ b/400-rest/src/main/java/software/wings/service/intfc/UserService.java
@@ -499,6 +499,16 @@ public interface UserService extends OwnedByAccount {
    * @return the String
    */
   String getInviteIdFromToken(String jwtToken);
+
+  /**
+   * Gets invites from accountId & userGroupId.
+   *
+   * @param accountId the account id
+   * @param userGroupId the userGroup id
+   * @return the invites list
+   */
+  List<UserInvite> getInvitesFromAccountIdAndUserGroupId(String accountId, String userGroupId);
+
   /**
    * Gets user account role.
    *

--- a/400-rest/src/test/java/software/wings/service/impl/UserServiceImplTest.java
+++ b/400-rest/src/test/java/software/wings/service/impl/UserServiceImplTest.java
@@ -12,6 +12,7 @@ import static io.harness.annotations.dev.HarnessTeam.PL;
 import static io.harness.beans.PageRequest.PageRequestBuilder.aPageRequest;
 import static io.harness.beans.PageResponse.PageResponseBuilder.aPageResponse;
 import static io.harness.beans.SearchFilter.Operator.HAS;
+import static io.harness.data.structure.UUIDGenerator.generateUuid;
 import static io.harness.ng.core.invites.dto.InviteOperationResponse.ACCOUNT_INVITE_ACCEPTED;
 import static io.harness.ng.core.invites.dto.InviteOperationResponse.ACCOUNT_INVITE_ACCEPTED_NEED_PASSWORD;
 import static io.harness.ng.core.invites.dto.InviteOperationResponse.FAIL;
@@ -42,6 +43,7 @@ import static software.wings.utils.WingsTestConstants.USER_EMAIL;
 import static software.wings.utils.WingsTestConstants.USER_NAME;
 import static software.wings.utils.WingsTestConstants.UUID;
 
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -816,6 +818,26 @@ public class UserServiceImplTest extends WingsBaseTest {
 
     List<User> userList = userServiceImpl.listUsers(pageRequest, "ACCOUNT_ID", "ab", 1, 30, false, true, false);
     assertThat(userList.size()).isEqualTo(0);
+  }
+
+  @Test
+  @Owner(developers = PRATEEK)
+  @Category(UnitTests.class)
+  public void shouldReturnPendingInvitesForMatchingGroup() {
+    String uuidString = generateUuid();
+    UserInvite userInvite = anUserInvite()
+                                .withUuid(UUIDGenerator.generateUuid())
+                                .withAccountId(ACCOUNT_ID)
+                                .withEmail(USER_EMAIL)
+                                .withName(USER_NAME)
+                                .withCompleted(Boolean.FALSE)
+                                .withUserGroups(asList(UserGroup.builder().uuid(uuidString).build()))
+                                .build();
+    wingsPersistence.save(userInvite);
+
+    List<UserInvite> inviteList = userServiceImpl.getInvitesFromAccountIdAndUserGroupId(ACCOUNT_ID, uuidString);
+    assertThat(inviteList).isNotNull();
+    assertThat(inviteList.size()).isEqualTo(1);
   }
 
   @Test


### PR DESCRIPTION
* [fix]: [PL-28358]: Add DB query improvement to fetch only matching accountId, userGroupId from userInvites collection for updation while unlinking SSO group

* [fix]: [PL-28358]: fix unit test, checkstyle issue

* [fix]: [PL-28358]: fix accountId key