### PR TITLE
feat: [CI-7838]: Add support for API URL in Gitlab connector (#46978)

### DIFF
--- a/440-connector-nextgen/src/main/java/io/harness/connector/entities/embedded/gitlabconnector/GitlabTokenApiAccess.java
+++ b/440-connector-nextgen/src/main/java/io/harness/connector/entities/embedded/gitlabconnector/GitlabTokenApiAccess.java
@@ -16,4 +16,5 @@ import org.springframework.data.annotation.TypeAlias;
 @TypeAlias("io.harness.connector.entities.embedded.gitlabconnector.GitlabTokenApiAccess")
 public class GitlabTokenApiAccess implements GitlabApiAccess {
   String tokenRef;
+  String apiUrl;
 }

--- a/440-connector-nextgen/src/main/java/io/harness/connector/mappers/gitlabconnector/GitlabDTOToEntity.java
+++ b/440-connector-nextgen/src/main/java/io/harness/connector/mappers/gitlabconnector/GitlabDTOToEntity.java
@@ -134,6 +134,7 @@ public class GitlabDTOToEntity implements ConnectorDTOToEntityMapper<GitlabConne
         final GitlabTokenSpecDTO tokenSpec = (GitlabTokenSpecDTO) spec;
         return GitlabTokenApiAccess.builder()
             .tokenRef(SecretRefHelper.getSecretConfigString(tokenSpec.getTokenRef()))
+            .apiUrl(tokenSpec.getApiUrl())
             .build();
       case OAUTH:
         final GitlabOauthDTO gitlabOauthDTO = (GitlabOauthDTO) spec;

--- a/440-connector-nextgen/src/main/java/io/harness/connector/mappers/gitlabconnector/GitlabEntityToDTO.java
+++ b/440-connector-nextgen/src/main/java/io/harness/connector/mappers/gitlabconnector/GitlabEntityToDTO.java
@@ -139,6 +139,7 @@ public class GitlabEntityToDTO implements ConnectorEntityToDTOMapper<GitlabConne
         final GitlabTokenSpecDTO gitlabTokenSpecDTO =
             GitlabTokenSpecDTO.builder()
                 .tokenRef(SecretRefHelper.createSecretRef(gitlabTokenApiAccess.getTokenRef()))
+                .apiUrl(gitlabTokenApiAccess.getApiUrl())
                 .build();
         return GitlabApiAccessDTO.builder().type(GitlabApiAccessType.TOKEN).spec(gitlabTokenSpecDTO).build();
       case OAUTH:

--- a/440-connector-nextgen/src/test/resources/schema/Connectors/all.json
+++ b/440-connector-nextgen/src/test/resources/schema/Connectors/all.json
@@ -4566,6 +4566,9 @@
             "tokenRef"
           ],
           "properties": {
+            "apiUrl": {
+              "type": "string"
+            },
             "tokenRef": {
               "type": "string"
             }

--- a/952-scm-java-client/src/main/java/io/harness/impl/scm/ScmGitProviderMapper.java
+++ b/952-scm-java-client/src/main/java/io/harness/impl/scm/ScmGitProviderMapper.java
@@ -27,6 +27,7 @@ import io.harness.delegate.beans.connector.scm.github.GithubConnectorDTO;
 import io.harness.delegate.beans.connector.scm.github.GithubOauthDTO;
 import io.harness.delegate.beans.connector.scm.github.GithubTokenSpecDTO;
 import io.harness.delegate.beans.connector.scm.gitlab.GitlabApiAccessDTO;
+import io.harness.delegate.beans.connector.scm.gitlab.GitlabApiAccessSpecDTO;
 import io.harness.delegate.beans.connector.scm.gitlab.GitlabConnectorDTO;
 import io.harness.delegate.beans.connector.scm.gitlab.GitlabOauthDTO;
 import io.harness.delegate.beans.connector.scm.gitlab.GitlabTokenSpecDTO;
@@ -161,7 +162,7 @@ public class ScmGitProviderMapper {
     return Provider.newBuilder()
         .setGitlab(createGitLabProvider(gitlabConnector))
         .setDebug(debug)
-        .setEndpoint(GitClientHelper.getGitlabApiURL(gitlabConnector.getUrl()))
+        .setEndpoint(GitClientHelper.getGitlabApiURL(gitlabConnector.getUrl(), getGitlabApiUrl(gitlabConnector)))
         .setSkipVerify(skipVerify)
         .setAdditionalCertsPath(getAdditionalCertsPath())
         .build();
@@ -234,5 +235,18 @@ public class ScmGitProviderMapper {
     GithubApiAccessDTO apiAccess = githubConnector.getApiAccess();
     GithubOauthDTO githubOauthDTO = (GithubOauthDTO) apiAccess.getSpec();
     return scmGitProviderHelper.getToken(githubOauthDTO.getTokenRef());
+  }
+
+  private String getGitlabApiUrl(GitlabConnectorDTO gitlabConnector) {
+    if (gitlabConnector.getApiAccess() == null || gitlabConnector.getApiAccess().getSpec() == null) {
+      // not expected
+      return null;
+    }
+    GitlabApiAccessSpecDTO spec = gitlabConnector.getApiAccess().getSpec();
+    if (spec instanceof GitlabTokenSpecDTO) {
+      GitlabTokenSpecDTO tokenSpec = (GitlabTokenSpecDTO) spec;
+      return tokenSpec.getApiUrl();
+    }
+    return null;
   }
 }

--- a/952-scm-java-client/src/test/java/io/harness/impl/scm/ScmGitProviderMapperTest.java
+++ b/952-scm-java-client/src/test/java/io/harness/impl/scm/ScmGitProviderMapperTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.impl.scm;
+
+import static io.harness.delegate.beans.connector.scm.GitAuthType.HTTP;
+import static io.harness.rule.OwnerRule.RUTVIJ_MEHTA;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.harness.category.element.UnitTests;
+import io.harness.delegate.beans.connector.scm.GitConnectionType;
+import io.harness.delegate.beans.connector.scm.gitlab.GitlabApiAccessDTO;
+import io.harness.delegate.beans.connector.scm.gitlab.GitlabApiAccessType;
+import io.harness.delegate.beans.connector.scm.gitlab.GitlabAuthenticationDTO;
+import io.harness.delegate.beans.connector.scm.gitlab.GitlabConnectorDTO;
+import io.harness.delegate.beans.connector.scm.gitlab.GitlabHttpCredentialsDTO;
+import io.harness.delegate.beans.connector.scm.gitlab.GitlabTokenSpecDTO;
+import io.harness.delegate.beans.connector.scm.gitlab.GitlabUsernameTokenDTO;
+import io.harness.encryption.SecretRefData;
+import io.harness.encryption.SecretRefHelper;
+import io.harness.product.ci.scm.proto.Provider;
+import io.harness.rule.Owner;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.InjectMocks;
+import org.mockito.MockitoAnnotations;
+
+public class ScmGitProviderMapperTest {
+  @InjectMocks ScmGitProviderMapper scmGitProviderMapper;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  @Owner(developers = RUTVIJ_MEHTA)
+  @Category(UnitTests.class)
+  public void testMapToGitlabProviderWithApiUrl() {
+    final String url = "https://harness.io/gitlab/rutvij.mehta1/spring-cloud-alibaba.git\n";
+    SecretRefData tokenRef = SecretRefHelper.createSecretRef("tokenRef");
+    tokenRef.setDecryptedValue("tokenRef".toCharArray());
+
+    GitlabHttpCredentialsDTO gitlabHttpCredentialsDTO =
+        GitlabHttpCredentialsDTO.builder().httpCredentialsSpec(GitlabUsernameTokenDTO.builder().build()).build();
+    GitlabAuthenticationDTO gitlabAuthenticationDTO =
+        GitlabAuthenticationDTO.builder().authType(HTTP).credentials(gitlabHttpCredentialsDTO).build();
+    GitlabApiAccessDTO gitlabApiAccessDTO =
+        GitlabApiAccessDTO.builder()
+            .type(GitlabApiAccessType.TOKEN)
+            .spec(GitlabTokenSpecDTO.builder().tokenRef(tokenRef).apiUrl("https://harness.io/gitlab/").build())
+            .build();
+
+    final GitlabConnectorDTO gitlabConnectorDTO = GitlabConnectorDTO.builder()
+                                                      .connectionType(GitConnectionType.REPO)
+                                                      .url(url)
+                                                      .authentication(gitlabAuthenticationDTO)
+                                                      .apiAccess(gitlabApiAccessDTO)
+                                                      .build();
+
+    final Provider provider = scmGitProviderMapper.mapToSCMGitProvider(gitlabConnectorDTO);
+    assertThat(provider).isNotNull();
+    assertThat(provider.getEndpoint()).isEqualTo("https://harness.io/gitlab/");
+  }
+
+  public void testMapToGitlabProviderWithApiUrlNoSlash() {
+    final String url = "https://harness.io/gitlab/rutvij.mehta1/spring-cloud-alibaba.git\n";
+    SecretRefData tokenRef = SecretRefHelper.createSecretRef("tokenRef");
+    tokenRef.setDecryptedValue("tokenRef".toCharArray());
+
+    GitlabHttpCredentialsDTO gitlabHttpCredentialsDTO =
+        GitlabHttpCredentialsDTO.builder().httpCredentialsSpec(GitlabUsernameTokenDTO.builder().build()).build();
+    GitlabAuthenticationDTO gitlabAuthenticationDTO =
+        GitlabAuthenticationDTO.builder().authType(HTTP).credentials(gitlabHttpCredentialsDTO).build();
+    GitlabApiAccessDTO gitlabApiAccessDTO =
+        GitlabApiAccessDTO.builder()
+            .type(GitlabApiAccessType.TOKEN)
+            .spec(GitlabTokenSpecDTO.builder().tokenRef(tokenRef).apiUrl("https://harness.io/gitlab").build())
+            .build();
+
+    final GitlabConnectorDTO gitlabConnectorDTO = GitlabConnectorDTO.builder()
+                                                      .connectionType(GitConnectionType.REPO)
+                                                      .url(url)
+                                                      .authentication(gitlabAuthenticationDTO)
+                                                      .apiAccess(gitlabApiAccessDTO)
+                                                      .build();
+
+    final Provider provider = scmGitProviderMapper.mapToSCMGitProvider(gitlabConnectorDTO);
+    assertThat(provider).isNotNull();
+    assertThat(provider.getEndpoint()).isEqualTo("https://harness.io/gitlab/");
+  }
+
+  @Test
+  @Owner(developers = RUTVIJ_MEHTA)
+  @Category(UnitTests.class)
+  public void testMapToGitlabProviderWithoutApiUrl() {
+    final String url = "https://harness.io/gitlab/rutvij.mehta1/spring-cloud-alibaba.git\n";
+    SecretRefData tokenRef = SecretRefHelper.createSecretRef("tokenRef");
+    tokenRef.setDecryptedValue("tokenRef".toCharArray());
+
+    GitlabHttpCredentialsDTO gitlabHttpCredentialsDTO =
+        GitlabHttpCredentialsDTO.builder().httpCredentialsSpec(GitlabUsernameTokenDTO.builder().build()).build();
+    GitlabAuthenticationDTO gitlabAuthenticationDTO =
+        GitlabAuthenticationDTO.builder().authType(HTTP).credentials(gitlabHttpCredentialsDTO).build();
+    GitlabApiAccessDTO gitlabApiAccessDTO = GitlabApiAccessDTO.builder()
+                                                .type(GitlabApiAccessType.TOKEN)
+                                                .spec(GitlabTokenSpecDTO.builder().tokenRef(tokenRef).build())
+                                                .build();
+
+    final GitlabConnectorDTO gitlabConnectorDTO = GitlabConnectorDTO.builder()
+                                                      .connectionType(GitConnectionType.REPO)
+                                                      .url(url)
+                                                      .authentication(gitlabAuthenticationDTO)
+                                                      .apiAccess(gitlabApiAccessDTO)
+                                                      .build();
+
+    final Provider provider = scmGitProviderMapper.mapToSCMGitProvider(gitlabConnectorDTO);
+    assertThat(provider).isNotNull();
+    assertThat(provider.getEndpoint()).isEqualTo("https://harness.io/");
+  }
+}

--- a/954-connector-beans/src/main/java/io/harness/delegate/beans/connector/scm/gitlab/GitlabTokenSpecDTO.java
+++ b/954-connector-beans/src/main/java/io/harness/delegate/beans/connector/scm/gitlab/GitlabTokenSpecDTO.java
@@ -29,4 +29,5 @@ import lombok.experimental.FieldDefaults;
     description = "This contains details of the information such as references of token needed for Gitlab API access")
 public class GitlabTokenSpecDTO implements GitlabApiAccessSpecDTO {
   @ApiModelProperty(dataType = "string") @NotNull @SecretReference SecretRefData tokenRef;
+  @ApiModelProperty(dataType = "string") String apiUrl;
 }

--- a/960-api-services/src/main/java/io/harness/git/GitClientHelper.java
+++ b/960-api-services/src/main/java/io/harness/git/GitClientHelper.java
@@ -235,7 +235,10 @@ public class GitClientHelper {
     return "https://";
   }
 
-  public static String getGitlabApiURL(String url) {
+  public static String getGitlabApiURL(String url, String apiUrl) {
+    if (!StringUtils.isBlank(apiUrl)) {
+      return StringUtils.stripEnd(apiUrl, "/") + "/";
+    }
     if (GitClientHelper.isGitlabSAAS(url)) {
       return "https://gitlab.com/";
     } else {

--- a/960-api-services/src/test/java/io/harness/git/GitClientHelperTest.java
+++ b/960-api-services/src/test/java/io/harness/git/GitClientHelperTest.java
@@ -473,22 +473,25 @@ public class GitClientHelperTest extends CategoryTest {
   @Owner(developers = DEV_MITTAL)
   @Category(UnitTests.class)
   public void testGetGitlabApiURL() {
-    assertThat(GitClientHelper.getGitlabApiURL("https://gitlab.com/devki.mittal/test.git"))
+    assertThat(GitClientHelper.getGitlabApiURL("https://gitlab.com/devki.mittal/test.git", ""))
         .isEqualTo("https://gitlab.com/");
-    assertThat(GitClientHelper.getGitlabApiURL("https://www.gitlab.com/devki.mittal/test.git"))
+    assertThat(GitClientHelper.getGitlabApiURL("https://www.gitlab.com/devki.mittal/test.git", ""))
         .isEqualTo("https://gitlab.com/");
-    assertThat(GitClientHelper.getGitlabApiURL("https://gitlab.com/devki.mittal/test"))
+    assertThat(GitClientHelper.getGitlabApiURL("https://gitlab.com/devki.mittal/test", ""))
         .isEqualTo("https://gitlab.com/");
-    assertThat(GitClientHelper.getGitlabApiURL("https://paypal.gitlab.com/devki.mittal/test.git"))
+    assertThat(GitClientHelper.getGitlabApiURL("https://paypal.gitlab.com/devki.mittal/test.git", ""))
         .isEqualTo("https://paypal.gitlab.com/");
-    assertThat(GitClientHelper.getGitlabApiURL("https://gitlab.paypal.com/devki.mittal/test.git"))
+    assertThat(GitClientHelper.getGitlabApiURL("https://gitlab.paypal.com/devki.mittal/test.git", ""))
         .isEqualTo("https://gitlab.paypal.com/");
-    assertThat(GitClientHelper.getGitlabApiURL("git@gitlab.com:devki.mittal/test.git"))
+    assertThat(GitClientHelper.getGitlabApiURL("git@gitlab.com:devki.mittal/test.git", ""))
         .isEqualTo("https://gitlab.com/");
-    assertThat(GitClientHelper.getGitlabApiURL("git@www.gitlab.com:devki.mittal/test.git"))
+    assertThat(GitClientHelper.getGitlabApiURL("git@www.gitlab.com:devki.mittal/test.git", ""))
         .isEqualTo("https://gitlab.com/");
-    assertThat(GitClientHelper.getGitlabApiURL("http://10.67.0.1/devkimittal/harness-core"))
+    assertThat(GitClientHelper.getGitlabApiURL("http://10.67.0.1/devkimittal/harness-core", ""))
         .isEqualTo("http://10.67.0.1/");
+    assertThat(GitClientHelper.getGitlabApiURL(
+                   "https://harness.io/gitlab/devki.mittal/test.git", "https://harness.io/gitlab/"))
+        .isEqualTo("https://harness.io/gitlab/");
   }
 
   @Test


### PR DESCRIPTION
* feat: [CI-7838]: Add support for API URL in Gitlab connector

* feat: [CI-7838]: Add support for API URL in Gitlab connector

* feat: [CI-7838]: Add UTs and address comments

* ut fix

---------

Co-authored-by: Dev Mittal <devki.mittal@harness.io>