### PR TITLE
fix: [CDS-59489]: K8s - only change refs of configmaps/secrets within manifests (#47011)

### DIFF
--- a/970-api-services-beans/src/test/resources/add-suffix-to-only-required-configmaps-secrets.yaml
+++ b/970-api-services-beans/src/test/resources/add-suffix-to-only-required-configmaps-secrets.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+data:
+  key3: value3
+kind: ConfigMap
+metadata:
+  name: harness-example-cfg
+---
+apiVersion: v1
+data:
+  key4: dmFsdWU0
+kind: Secret
+metadata:
+  name: harness-example-secret
+type: Opaque
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: harness-example-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: harness-example
+      harness.io/color: blue
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: harness-example
+        harness.io/color: blue
+        harness.io/release-name: release-ca4c68703b24d14863ec51a4b59758642463bb28
+    spec:
+      volumes:
+      - name: cfg
+        configMap:
+          name: harness-example-cfg
+      - name: secret
+        secret:
+          secretName: harness-example-secret
+      containers:
+      - envFrom:
+          - configMapRef:
+              name: harness-example-cfg
+          - secretRef:
+              name: harness-example-secret
+        image: nginx:latest
+        imagePullPolicy: Always
+        env:
+        - name: SOME_KEY_CFG
+          valueFrom:
+            configMapKeyRef:
+              name: harness-external-cfg
+              key: key3
+        - name: SOME_KEY_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: harness-external-secret
+              key: key4
+        name: harness-example
+        volumeMounts:
+          - name: cfg
+            mountPath: /etc/cfg
+            readOnly: true
+          - name: secret
+            mountPath: /certs
+            readOnly: true


### PR DESCRIPTION
* fix: [CDS-59489]: only change refs of configmap/secret which are present in manifests
* fix: [CDS-59489]: refactor repeated code
* fix: [CDS-59489]: some code smell fixes