### PR TITLE
fix: [CDS-59244]: Don't send executable statuses explicitly in ConfigFiles step (#47041)

### DIFF
--- a/125-cd-nextgen/modules/common/core/src/main/java/io/harness/cdng/configfile/steps/ConfigFilesStepV2.java
+++ b/125-cd-nextgen/modules/common/core/src/main/java/io/harness/cdng/configfile/steps/ConfigFilesStepV2.java
@@ -171,7 +171,7 @@ public class ConfigFilesStepV2 extends AbstractConfigFileStep
     if (EmptyPredicate.isEmpty(configFiles)) {
       logCallback.saveExecutionLog(
           "No config files configured in the service. configFiles expressions will not work", LogLevel.WARN);
-      return AsyncExecutableResponse.newBuilder().setStatus(Status.SKIPPED).build();
+      return AsyncExecutableResponse.newBuilder().build();
     }
     cdExpressionResolver.updateExpressions(ambiance, configFiles);
     JavaxValidator.validateBeanOrThrow(new ConfigFileValidatorDTO(configFiles));
@@ -221,7 +221,7 @@ public class ConfigFilesStepV2 extends AbstractConfigFileStep
 
     serviceStepsHelper.publishTaskIdsStepDetailsForServiceStep(ambiance, taskIds, CONFIG_FILES_STEP_DETAIL_KEY);
 
-    return AsyncExecutableResponse.newBuilder().addAllCallbackIds(taskIds).setStatus(Status.SUCCEEDED).build();
+    return AsyncExecutableResponse.newBuilder().addAllCallbackIds(taskIds).build();
   }
 
   private String createGitDelegateTask(

--- a/125-cd-nextgen/src/test/java/io/harness/cdng/configfile/steps/ConfigFilesStepV2Test.java
+++ b/125-cd-nextgen/src/test/java/io/harness/cdng/configfile/steps/ConfigFilesStepV2Test.java
@@ -165,7 +165,6 @@ public class ConfigFilesStepV2Test extends CategoryTest {
 
     AsyncExecutableResponse stepResponse = step.executeAsyncAfterRbac(buildAmbiance(), new EmptyStepParameters(), null);
 
-    assertThat(stepResponse.getStatus()).isEqualTo(Status.SKIPPED);
     verify(mockSweepingOutputService, never()).consume(any(), anyString(), any(), anyString());
   }
 
@@ -223,7 +222,6 @@ public class ConfigFilesStepV2Test extends CategoryTest {
         .consume(any(), eq("CONFIG_FILES_STEP_V2"), captor.capture(), eq("STAGE"));
     verify(pipelineRbacHelper, times(1)).checkRuntimePermissions(any(), any(List.class), any(Boolean.class));
     ConfigFilesStepV2SweepingOutput outcome = captor.getValue();
-    assertThat(stepResponse.getStatus()).isEqualTo(Status.SUCCEEDED);
     assertThat(outcome.getGitConfigFileOutcomesMapTaskIds().size()).isEqualTo(3);
   }
 
@@ -274,7 +272,6 @@ public class ConfigFilesStepV2Test extends CategoryTest {
         .consume(any(), eq("CONFIG_FILES_STEP_V2"), captor.capture(), eq("STAGE"));
     verify(pipelineRbacHelper, times(1)).checkRuntimePermissions(any(), any(List.class), any(Boolean.class));
     ConfigFilesStepV2SweepingOutput outcome = captor.getValue();
-    assertThat(stepResponse.getStatus()).isEqualTo(Status.SUCCEEDED);
     assertThat(outcome.getHarnessConfigFileOutcomes().size()).isEqualTo(3);
   }
 


### PR DESCRIPTION
* fix: [CDS-59244]: don't send skipped status while running
* fix: [CDS-59244]: don't send succeeded status while running
* fix: [CDS-59244]: fix ut