### PR TITLE
[feat]: [CDS-68130]: Post retry action as PRB should work (#47048)

### DIFF
--- a/clients/pipeline-service/pms-sdk-core/src/main/java/io/harness/advisers/retry/RetryAdviserWithRollback.java
+++ b/clients/pipeline-service/pms-sdk-core/src/main/java/io/harness/advisers/retry/RetryAdviserWithRollback.java
@@ -13,6 +13,7 @@ import static io.harness.pms.contracts.execution.Status.INTERVENTION_WAITING;
 import static io.harness.pms.execution.utils.StatusUtils.retryableStatuses;
 
 import io.harness.advisers.CommonAdviserTypes;
+import io.harness.advisers.pipelinerollback.OnFailPipelineRollbackAdviser;
 import io.harness.advisers.rollback.OnFailRollbackOutput;
 import io.harness.advisers.rollback.RollbackStrategy;
 import io.harness.annotations.dev.OwnedBy;
@@ -52,6 +53,7 @@ import lombok.extern.slf4j.Slf4j;
 public class RetryAdviserWithRollback implements Adviser {
   @Inject private KryoSerializer kryoSerializer;
   @Inject ExecutionSweepingOutputService executionSweepingOutputService;
+  @Inject OnFailPipelineRollbackAdviser onFailPipelineRollbackAdviser;
 
   public static final AdviserType ADVISER_TYPE =
       AdviserType.newBuilder().setType(CommonAdviserTypes.RETRY_WITH_ROLLBACK.name()).build();
@@ -143,6 +145,8 @@ public class RetryAdviserWithRollback implements Adviser {
             .setMarkAsFailureAdvise(builder.build())
             .setType(AdviseType.MARK_AS_FAILURE)
             .build();
+      case PIPELINE_ROLLBACK:
+        return onFailPipelineRollbackAdviser.onAdviseEvent(AdvisingEvent.builder().ambiance(ambiance).build());
       default:
         throw new IllegalStateException("Unexpected value: " + parameters.getRepairActionCodeAfterRetry());
     }

--- a/clients/pipeline-service/pms-sdk-core/src/main/java/io/harness/plancreator/steps/GenericPlanCreatorUtils.java
+++ b/clients/pipeline-service/pms-sdk-core/src/main/java/io/harness/plancreator/steps/GenericPlanCreatorUtils.java
@@ -118,6 +118,8 @@ public class GenericPlanCreatorUtils {
         return RepairActionCode.RETRY;
       case MARK_AS_FAILURE:
         return RepairActionCode.MARK_AS_FAILURE;
+      case PIPELINE_ROLLBACK:
+        return RepairActionCode.PIPELINE_ROLLBACK;
       default:
         throw new InvalidRequestException(
 

--- a/clients/pipeline-service/pms-sdk-core/src/main/java/io/harness/plancreator/steps/GenericStepPMSPlanCreator.java
+++ b/clients/pipeline-service/pms-sdk-core/src/main/java/io/harness/plancreator/steps/GenericStepPMSPlanCreator.java
@@ -463,6 +463,8 @@ public abstract class GenericStepPMSPlanCreator implements PartialPlanCreator<St
         return RepairActionCode.RETRY;
       case MARK_AS_FAILURE:
         return RepairActionCode.MARK_AS_FAILURE;
+      case PIPELINE_ROLLBACK:
+        return RepairActionCode.PIPELINE_ROLLBACK;
       default:
         throw new InvalidRequestException(
             action.toString() + " Failure action doesn't have corresponding RepairAction Code.");

--- a/clients/pipeline-service/pms-sdk-core/src/test/java/io/harness/advisers/rollback/RollbackStrategyTest.java
+++ b/clients/pipeline-service/pms-sdk-core/src/test/java/io/harness/advisers/rollback/RollbackStrategyTest.java
@@ -29,8 +29,8 @@ public class RollbackStrategyTest extends CategoryTest {
   @Owner(developers = NAMAN)
   @Category(UnitTests.class)
   public void testFromRepairActionCode() {
-    List<RepairActionCode> validRepairActionCodes =
-        Arrays.asList(RepairActionCode.STAGE_ROLLBACK, RepairActionCode.STEP_GROUP_ROLLBACK, RepairActionCode.UNKNOWN);
+    List<RepairActionCode> validRepairActionCodes = Arrays.asList(RepairActionCode.STAGE_ROLLBACK,
+        RepairActionCode.STEP_GROUP_ROLLBACK, RepairActionCode.PIPELINE_ROLLBACK, RepairActionCode.UNKNOWN);
     for (RepairActionCode value : RepairActionCode.values()) {
       if (!validRepairActionCodes.contains(value)) {
         assertThat(RollbackStrategy.fromRepairActionCode(value)).isNull();
@@ -42,6 +42,8 @@ public class RollbackStrategyTest extends CategoryTest {
     assertThat(RollbackStrategy.fromRepairActionCode(RepairActionCode.STEP_GROUP_ROLLBACK))
         .isEqualTo(RollbackStrategy.STEP_GROUP_ROLLBACK);
     assertThat(RollbackStrategy.fromRepairActionCode(RepairActionCode.UNKNOWN)).isEqualTo(RollbackStrategy.UNKNOWN);
+    assertThat(RollbackStrategy.fromRepairActionCode(RepairActionCode.PIPELINE_ROLLBACK))
+        .isEqualTo(RollbackStrategy.PIPELINE_ROLLBACK);
   }
 
   @Test

--- a/pipeline-service/modules/pms-contracts/src/main/proto/io/harness/pms/contracts/commons/repair_action_code.proto
+++ b/pipeline-service/modules/pms-contracts/src/main/proto/io/harness/pms/contracts/commons/repair_action_code.proto
@@ -21,4 +21,5 @@ enum RepairActionCode {
   STEP_GROUP_ROLLBACK = 8;
   CUSTOM_FAILURE = 9;
   MARK_AS_FAILURE = 10;
+  PIPELINE_ROLLBACK = 11;
 }

--- a/pipeline-service/service/src/main/java/io/harness/pms/plan/execution/service/PMSExecutionServiceImpl.java
+++ b/pipeline-service/service/src/main/java/io/harness/pms/plan/execution/service/PMSExecutionServiceImpl.java
@@ -43,6 +43,7 @@ import io.harness.ng.core.common.beans.NGTag.NGTagKeys;
 import io.harness.pms.contracts.interrupts.InterruptConfig;
 import io.harness.pms.contracts.interrupts.IssuedBy;
 import io.harness.pms.contracts.interrupts.ManualIssuer;
+import io.harness.pms.contracts.plan.ExecutionMode;
 import io.harness.pms.execution.ExecutionStatus;
 import io.harness.pms.execution.TimeRange;
 import io.harness.pms.filter.utils.ModuleInfoFilterUtils;
@@ -145,6 +146,7 @@ public class PMSExecutionServiceImpl implements PMSExecutionService {
     }
 
     criteria.and(PlanExecutionSummaryKeys.isLatestExecution).ne(!isLatest);
+    criteria.and(PlanExecutionSummaryKeys.executionMode).ne(ExecutionMode.PIPELINE_ROLLBACK);
 
     Criteria filterCriteria = new Criteria();
     if (EmptyPredicate.isNotEmpty(filterIdentifier) && filterProperties != null) {


### PR DESCRIPTION
* Preserve in RB mode

* add new helper for rollback mode

* implement transformPlanForRollbackMode

* add stage and higher level nodes

* remove non required rollback modes

* build fix

* --amend

* add api for post prod

* proper transformations to PlanExecutionMetadata and Plan Nodes

* diff way to transform plan

* reverse order of stages

* add advisorObtainmentsForRollbackMode to PlanNode

* add advisor to identity nodes

* add proper advisor

* remove original advisor response if advisor obtainments are there

* Change PlanNode to Node while queueing advising event

* send advise event in IdentityNodeExecutionStrategy if advisors are there

* skip identity nodes in rollback mode graph

* comment out one line of code

* Use rollback mode to change rollback steps' when condition

* change bool to enum

* use execution mode in to transform plan

* use postExecutionRollback instead of postProdRollback

* separate method for plan transformation

* add comments

* [feat]: [PIE-8016]: Remove rollback stages created during plan creation

* add detailed comment

* --separate method

* use map in pipeline service

* add comment

* Change step category of StagesStep

* --amends

* extract out separate methods

* remove accidental changes

* use map instead of list for advisors

* add todo

* Pipeline Rollback POC

* add method for Pipeline Rollback start

* add advisor for pipeline rollback mode to stepsNode

* rollback stage step impl

* unused imports

* class movement

* --amend

* Add fields in PipelineExecutionSummaryEntity

* add step params

* add rollback graph

* add graph layout node for prb stage

* update next id for prev stage when prb starts

* advisor changes with todos

* remove unused field

* remove unused import

* use ternary operator

* update instead of get

* start prb on failure part 1

* merge

* run prb only on failure

* directly run prb stage after failed stage

* use next stage advisor for starting prb

* use stage id to show execution details of rb stages

* delete PipelineRollbackStartAdvisor

* --amend

* some bug fixes

* package name change

* need to use stage fqn

* use stage fqn for parallel and strategy

* revert

* package rename

* movement

* remove sweeping output from rollback stage step

* remove prb from strategy next node

* remove prb sweeping output

* constant for stage name

* static import

* --amend

* remove fqn check

* add comment

* add comment

* Add ExecutionModeUtils

* move method

* remove duplicate method

* remove duplicate method

* [feat]: [PIE-9192]: Fill pipeline rollback graph info into rollbackGraph field

* --revert

* next step handling in rb mode

* test

* separate class for building rollback graph

* tests

* add comment to explain field

* add pojo for rollback info

* update key

* add method

* separate method for decorating dependencies

* test

* [feat]: [PIE-9489]: Add Pipeline Rollback Stage config, plan creator, and step

* --merge

* --merge

* test fix

* --code format

* test fixes

* add tests

* add tests

* --merge

* --merge

* code format

* test fixes

* --merge

* --merge

* next stage advisor changes

* --merge

* --merge

* use ff

* use objects.equals

* null check

* identity node check on strategy level

* add parent stage info

* handling pipeline stage at the end

* remove execution graph from top if rollback graph has it

* block prb-ed executions for retry

* filter out prb executions from executions list view

* dont add prb executions to recent executions of a pipeline

* post retry action

* test fix