### PR TITLE
[feat]: [CI-7680]: Allow cache intelligence to use S3 buckets (#46700)

### DIFF
--- a/332-ci-manager/config/ci-manager-config.yml
+++ b/332-ci-manager/config/ci-manager-config.yml
@@ -187,6 +187,12 @@ ciExecutionServiceConfig:
   cacheIntelligenceConfig:
     bucket: "gcp_bucket"
     serviceKey: "gcp_service_key"
+  cacheIntelligenceS3Config:
+    bucket: "s3_bucket"
+    accessKey: "s3_access_key"
+    accessSecret: "s3_access_secret"
+    region: "s3_bucket_region"
+    endpoint: "s3_endpoint"
   dockerLayerCachingConfig:
     endpoint: "endpoint"
     bucket: "bucket"

--- a/332-ci-manager/container/scripts/replace_configs.sh
+++ b/332-ci-manager/container/scripts/replace_configs.sh
@@ -139,6 +139,26 @@ if [[ "" != "$CACHE_SERVICE_KEY" ]]; then
   export CACHE_SERVICE_KEY; yq -i '.ciExecutionServiceConfig.cacheIntelligenceConfig.serviceKey=env(CACHE_SERVICE_KEY)' $CONFIG_FILE
 fi
 
+if [[ "" != "$CACHE_S3_BUCKET" ]]; then
+  export CACHE_S3_BUCKET; yq -i '.ciExecutionServiceConfig.cacheIntelligenceS3Config.bucket=env(CACHE_S3_BUCKET)' $CONFIG_FILE
+fi
+
+if [[ "" != "$CACHE_S3_ACCESS_KEY" ]]; then
+  export CACHE_S3_ACCESS_KEY; yq -i '.ciExecutionServiceConfig.cacheIntelligenceS3Config.accessKey=env(CACHE_S3_ACCESS_KEY)' $CONFIG_FILE
+fi
+
+if [[ "" != "$CACHE_S3_ACCESS_SECRET" ]]; then
+  export CACHE_S3_ACCESS_SECRET; yq -i '.ciExecutionServiceConfig.cacheIntelligenceS3Config.accessSecret=env(CACHE_S3_ACCESS_SECRET)' $CONFIG_FILE
+fi
+
+if [[ "" != "$CACHE_S3_REGION" ]]; then
+  export CACHE_S3_REGION; yq -i '.ciExecutionServiceConfig.cacheIntelligenceS3Config.region=env(CACHE_S3_REGION)' $CONFIG_FILE
+fi
+
+if [[ "" != "$CACHE_S3_ENDPOINT" ]]; then
+  export CACHE_S3_ENDPOINT; yq -i '.ciExecutionServiceConfig.cacheIntelligenceS3Config.endpoint=env(CACHE_S3_ENDPOINT)' $CONFIG_FILE
+fi
+
 if [[ "" != "$HOSTED_VM_SPLIT_LINUX_AMD64_POOL" ]]; then
   export HOSTED_VM_SPLIT_LINUX_AMD64_POOL; yq -i '.ciExecutionServiceConfig.hostedVmConfig.splitLinuxAmd64Pool=env(HOSTED_VM_SPLIT_LINUX_AMD64_POOL)' $CONFIG_FILE
 fi

--- a/332-ci-manager/service/src/main/java/io/harness/ci/beans/config/CICacheIntelligenceS3Config.java
+++ b/332-ci-manager/service/src/main/java/io/harness/ci/beans/config/CICacheIntelligenceS3Config.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.ci.config;
+
+import io.harness.annotation.RecasterAlias;
+
+import lombok.Builder;
+import lombok.Value;
+import org.springframework.data.annotation.TypeAlias;
+
+@Value
+@Builder
+@TypeAlias("ciCacheIntelligenceS3Config")
+@RecasterAlias("io.harness.ci.config.CICacheIntelligenceS3Config")
+public class CICacheIntelligenceS3Config {
+  String bucket;
+  String accessKey;
+  String accessSecret;
+  String region;
+  String endpoint;
+}

--- a/332-ci-manager/service/src/main/java/io/harness/ci/beans/config/CIExecutionServiceConfig.java
+++ b/332-ci-manager/service/src/main/java/io/harness/ci/beans/config/CIExecutionServiceConfig.java
@@ -27,6 +27,7 @@ public class CIExecutionServiceConfig extends ExecutionServiceConfig {
   String ciImageTag;
   CIStepConfig stepConfig;
   CICacheIntelligenceConfig cacheIntelligenceConfig;
+  CICacheIntelligenceS3Config cacheIntelligenceS3Config;
   ExecutionLimits executionLimits;
   QueueServiceClientConfig queueServiceClientConfig;
   HostedVmConfig hostedVmConfig;
@@ -40,7 +41,8 @@ public class CIExecutionServiceConfig extends ExecutionServiceConfig {
   public CIExecutionServiceConfig(String addonImageTag, String liteEngineImageTag, String defaultInternalImageConnector,
       String delegateServiceEndpointVariableValue, Integer defaultMemoryLimit, Integer defaultCPULimit,
       Integer pvcDefaultStorageSize, String addonImage, String liteEngineImage, boolean isLocal, String ciImageTag,
-      CIStepConfig stepConfig, CICacheIntelligenceConfig cacheIntelligenceConfig, ExecutionLimits executionLimits,
+      CIStepConfig stepConfig, CICacheIntelligenceConfig cacheIntelligenceConfig,
+      CICacheIntelligenceS3Config cacheIntelligenceS3Config, ExecutionLimits executionLimits,
       QueueServiceClientConfig queueServiceClientConfig, HostedVmConfig hostedVmConfig, STOStepConfig stoStepConfig,
       Integer remoteDebugTimeout, CIDockerLayerCachingConfig dockerLayerCachingConfig) {
     super(addonImageTag, liteEngineImageTag, defaultInternalImageConnector, delegateServiceEndpointVariableValue,
@@ -48,6 +50,7 @@ public class CIExecutionServiceConfig extends ExecutionServiceConfig {
     this.ciImageTag = ciImageTag;
     this.stepConfig = stepConfig;
     this.cacheIntelligenceConfig = cacheIntelligenceConfig;
+    this.cacheIntelligenceS3Config = cacheIntelligenceS3Config;
     this.executionLimits = executionLimits;
     this.stoStepConfig = stoStepConfig;
     this.queueServiceClientConfig = queueServiceClientConfig;

--- a/332-ci-manager/service/src/main/java/io/harness/ci/execution/commonconstants/CIExecutionConstants.java
+++ b/332-ci-manager/service/src/main/java/io/harness/ci/execution/commonconstants/CIExecutionConstants.java
@@ -37,6 +37,7 @@ public class CIExecutionConstants extends ContainerExecutionConstants {
   public static final String SAVE_CACHE_STEP_NAME = "Save Cache to Harness";
   public static final String CACHE_ARCHIVE_TYPE_TAR = "tar";
   public static final String CACHE_GCS_BACKEND = "gcs";
+  public static final String CACHE_S3_BACKEND = "s3";
 
   // Constant for
 

--- a/332-ci-manager/service/src/main/java/io/harness/ci/execution/integrationstage/CIStepGroupUtils.java
+++ b/332-ci-manager/service/src/main/java/io/harness/ci/execution/integrationstage/CIStepGroupUtils.java
@@ -37,6 +37,7 @@ import static io.harness.data.structure.UUIDGenerator.generateUuid;
 
 import io.harness.annotations.dev.HarnessTeam;
 import io.harness.annotations.dev.OwnedBy;
+import io.harness.beans.FeatureName;
 import io.harness.beans.execution.ExecutionSource;
 import io.harness.beans.execution.ManualExecutionSource;
 import io.harness.beans.executionargs.CIExecutionArgs;
@@ -345,6 +346,9 @@ public class CIStepGroupUtils {
     String uuid = generateUuid();
     // image is not controlled by user
     String restoreCacheImage = ciExecutionServiceConfig.getStepConfig().getCacheGCSConfig().getImage();
+    if (featureFlagService.isEnabled(FeatureName.CI_USE_S3_FOR_CACHE, accountId)) {
+      restoreCacheImage = ciExecutionServiceConfig.getStepConfig().getCacheS3Config().getImage();
+    }
 
     List<String> entrypoint = ciExecutionServiceConfig.getStepConfig().getCacheGCSConfig().getEntrypoint();
 
@@ -393,6 +397,9 @@ public class CIStepGroupUtils {
     String uuid = generateUuid();
     // image is not controlled by user
     String saveCacheImage = ciExecutionServiceConfig.getStepConfig().getCacheGCSConfig().getImage();
+    if (featureFlagService.isEnabled(FeatureName.CI_USE_S3_FOR_CACHE, accountId)) {
+      saveCacheImage = ciExecutionServiceConfig.getStepConfig().getCacheS3Config().getImage();
+    }
 
     List<String> entrypoint = ciExecutionServiceConfig.getStepConfig().getCacheGCSConfig().getEntrypoint();
 

--- a/332-ci-manager/service/src/test/resources/recaster/alias/alias.txt
+++ b/332-ci-manager/service/src/test/resources/recaster/alias/alias.txt
@@ -358,3 +358,4 @@ io.harness.beans.yaml.extended.runtime.CloudRuntime
 io.harness.beans.steps.nodes.SecurityNode
 io.harness.beans.steps.nodes.GCSUploadNode
 io.harness.ci.beans.entities.PluginMetadataConfig
+io.harness.ci.config.CICacheIntelligenceS3Config

--- a/956-feature-flag-beans/src/main/java/io/harness/beans/FeatureName.java
+++ b/956-feature-flag-beans/src/main/java/io/harness/beans/FeatureName.java
@@ -731,7 +731,8 @@ public enum FeatureName {
       "Enables new default page size for several listing pages like pipelines, access control, executions, connectors, etc.",
       HarnessTeam.PL),
   CDS_SUPPORT_TICKET_DEFLECTION("Enable api to create zendesk ticket and for generating coveo token", HarnessTeam.CDP),
-  SRM_SPLUNK_SIGNALFX("Will enable SignalFX metric health source in SRM", HarnessTeam.CV);
+  SRM_SPLUNK_SIGNALFX("Will enable SignalFX metric health source in SRM", HarnessTeam.CV),
+  CI_USE_S3_FOR_CACHE("Use S3 bucket for cache intelligence instead of GCP", HarnessTeam.CI);
 
   @Deprecated
   FeatureName() {


### PR DESCRIPTION
* [CI-7680]: Add OVH bucket option, use cache executable

* [CI-7680]: Add OVH bucket option, use cache executable

* [feat]: [CI-7680]: Allow cache intelligence to use OVH buckets

* [feat]: [CI-7680]: Allow cache intelligence to use OVH buckets

* [feat]: [CI-7680]: Allow cache intelligence to use OVH buckets

* [feat]: [CI-7680]: Allow cache intelligence to use OVH buckets

* [feat]: [CI-7680]: Change FF name

* [feat]: [CI-7680]: Allow cache intelligence to use OVH buckets

* Revert "[feat]: [CI-7680]: Allow cache intelligence to use OVH buckets"

This reverts commit 727e00d608499a8a59c77df4195bc86345c9777b.

* [feat]: [CI-7680]: Allow cache intelligence to use OVH buckets

* [feat]: [CI-7680]: Allow cache intelligence to use OVH buckets

* [feat]: [CI-7680]: Codeformat

* Update VmPluginStepSerializer.java

* [feat]: [CI-7680]: Replace ovh with s3

* [feat]: [CI-7680]: Allow cache intelligence to use S3 buckets

* [feat]: [CI-7680]: Allow cache intelligence to use S3 buckets

* [feat]: [CI-7680]: Allow cache intelligence to use S3 buckets

* [feat]: [CI-7680]: Allow cache intelligence to use S3 buckets

* [feat]: [CI-7680]: Allow cache intelligence to use S3 buckets

* [feat]: [CI-7680]: Allow cache intelligence to use S3 buckets

---------

Signed-off-by: Anurag Madnawat <anurag.madnawat@harness.io>
Co-authored-by: Jamie Li <tianyi.li@harness.io>