### PR TITLE
feat: [CDS-58438]: Login to the cluster before executing the kubeconfig file (#46829)

### DIFF
--- a/930-delegate-tasks/src/main/java/io/harness/delegate/task/gcp/helpers/GkeClusterHelper.java
+++ b/930-delegate-tasks/src/main/java/io/harness/delegate/task/gcp/helpers/GkeClusterHelper.java
@@ -15,7 +15,7 @@ import static io.harness.eraro.ErrorCode.CLUSTER_NOT_FOUND;
 import static io.harness.k8s.K8sConstants.API_VERSION;
 import static io.harness.k8s.K8sConstants.GCP_AUTH_PLUGIN_BINARY;
 import static io.harness.k8s.K8sConstants.GCP_AUTH_PLUGIN_INSTALL_HINT;
-import static io.harness.k8s.model.kubeconfig.KubeConfigAuthPluginHelper.isExecAuthPluginBinaryAvailable;
+import static io.harness.k8s.K8sConstants.GOOGLE_APPLICATION_CREDENTIALS_FLAG;
 import static io.harness.threading.Morpheus.sleep;
 
 import static java.lang.String.format;
@@ -38,6 +38,7 @@ import io.harness.k8s.model.KubernetesConfig;
 import io.harness.k8s.model.KubernetesConfig.KubernetesConfigBuilder;
 import io.harness.k8s.model.kubeconfig.Exec;
 import io.harness.k8s.model.kubeconfig.InteractiveMode;
+import io.harness.k8s.model.kubeconfig.KubeConfigAuthPluginHelper;
 import io.harness.logging.LogCallback;
 import io.harness.serializer.JsonUtils;
 
@@ -63,6 +64,7 @@ import com.google.inject.Singleton;
 import java.io.IOException;
 import java.time.Clock;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -248,7 +250,7 @@ public class GkeClusterHelper {
       }
       kubernetesConfigBuilder.serviceAccountTokenSupplier(tokenSupplier);
     }
-    if (isExecAuthPluginBinaryAvailable(GCP_AUTH_PLUGIN_BINARY, logCallback)) {
+    if (KubeConfigAuthPluginHelper.isExecAuthPluginBinaryAvailable(GCP_AUTH_PLUGIN_BINARY, logCallback)) {
       kubernetesConfigBuilder.authType(KubernetesClusterAuthType.EXEC_OAUTH);
       kubernetesConfigBuilder.exec(getGkeUserExecConfig());
     }
@@ -331,6 +333,7 @@ public class GkeClusterHelper {
     return Exec.builder()
         .apiVersion(API_VERSION)
         .command(GCP_AUTH_PLUGIN_BINARY)
+        .args(Collections.singletonList(GOOGLE_APPLICATION_CREDENTIALS_FLAG))
         .interactiveMode(InteractiveMode.NEVER)
         .provideClusterInfo(true)
         .installHint(GCP_AUTH_PLUGIN_INSTALL_HINT)

--- a/930-delegate-tasks/src/main/java/software/wings/delegatetasks/azure/taskhelper/AzureAsyncTaskHelper.java
+++ b/930-delegate-tasks/src/main/java/software/wings/delegatetasks/azure/taskhelper/AzureAsyncTaskHelper.java
@@ -8,6 +8,8 @@
 package software.wings.delegatetasks.azure;
 
 import static io.harness.azure.model.AzureConstants.AZURE_AUTH_PLUGIN_INSTALL_HINT;
+import static io.harness.azure.model.AzureConstants.AZURE_CONFIG_DIR;
+import static io.harness.azure.model.AzureConstants.AZURE_LOGIN_CONFIG_DIR_PATH;
 import static io.harness.azure.model.AzureConstants.DEPLOYMENT_SLOT_FULL_NAME_PATTERN;
 import static io.harness.azure.model.AzureConstants.DEPLOYMENT_SLOT_NON_PRODUCTION_TYPE;
 import static io.harness.azure.model.AzureConstants.DEPLOYMENT_SLOT_PRODUCTION_TYPE;
@@ -108,6 +110,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -643,6 +646,8 @@ public class AzureAsyncTaskHelper {
         String apiServerId = Exec.getValueFromArgsList(userConfig.getExec().getArgs(), KUBECFG_ARGS_SERVER_ID);
         azureKubeConfig.setAadToken(fetchAksAADToken(azureConfig, apiServerId));
         Map<String, String> env = new HashMap<>();
+        env.put(AZURE_CONFIG_DIR,
+            Paths.get(workingDirectory, AZURE_LOGIN_CONFIG_DIR_PATH).normalize().toAbsolutePath().toString());
         if (AzureAuthenticationType.SERVICE_PRINCIPAL_CERT == azureConfig.getAzureAuthenticationType()) {
           AzureCliClient.loginToAksCluster(azureConfig, env, workingDirectory, logCallback);
         }

--- a/930-delegate-tasks/src/test/java/io/harness/delegate/task/azure/AzureAsyncTaskHelperTest.java
+++ b/930-delegate-tasks/src/test/java/io/harness/delegate/task/azure/AzureAsyncTaskHelperTest.java
@@ -8,6 +8,7 @@
 package io.harness.delegate.task.azure;
 
 import static io.harness.azure.model.AzureConstants.AZURE_AUTH_PLUGIN_INSTALL_HINT;
+import static io.harness.azure.model.AzureConstants.AZURE_CONFIG_DIR;
 import static io.harness.rule.OwnerRule.BUHA;
 import static io.harness.rule.OwnerRule.FILIP;
 import static io.harness.rule.OwnerRule.MLUKIC;
@@ -92,6 +93,7 @@ import io.harness.exception.NestedExceptionUtils;
 import io.harness.filesystem.FileIo;
 import io.harness.filesystem.LazyAutoCloseableWorkingDirectory;
 import io.harness.k8s.model.KubernetesConfig;
+import io.harness.k8s.model.kubeconfig.EnvVariable;
 import io.harness.k8s.model.kubeconfig.Exec;
 import io.harness.k8s.model.kubeconfig.InteractiveMode;
 import io.harness.k8s.model.kubeconfig.KubeConfigAuthPluginHelper;
@@ -114,6 +116,7 @@ import com.google.common.io.Resources;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1023,7 +1026,8 @@ public class AzureAsyncTaskHelperTest extends CategoryTest {
                        .installHint(AZURE_AUTH_PLUGIN_INSTALL_HINT)
                        .provideClusterInfo(false)
                        .interactiveMode(InteractiveMode.NEVER)
-                       .env(Collections.emptyList())
+                       .env(List.of(new EnvVariable(
+                           AZURE_CONFIG_DIR, Paths.get(WORKING_DIR, ".azure").normalize().toAbsolutePath().toString())))
                        .args(getArgsForKubeconfig(azureConfig.getAzureAuthenticationType()))
                        .build());
   }

--- a/930-delegate-tasks/src/test/java/io/harness/delegate/task/gcp/helpers/GkeClusterHelperTest.java
+++ b/930-delegate-tasks/src/test/java/io/harness/delegate/task/gcp/helpers/GkeClusterHelperTest.java
@@ -11,6 +11,7 @@ import static io.harness.delegate.task.gcp.helpers.GcpHelperService.LOCATION_DEL
 import static io.harness.k8s.K8sConstants.API_VERSION;
 import static io.harness.k8s.K8sConstants.GCP_AUTH_PLUGIN_BINARY;
 import static io.harness.k8s.K8sConstants.GCP_AUTH_PLUGIN_INSTALL_HINT;
+import static io.harness.k8s.K8sConstants.GOOGLE_APPLICATION_CREDENTIALS_FLAG;
 import static io.harness.rule.OwnerRule.ABHINAV2;
 import static io.harness.rule.OwnerRule.ACASIAN;
 import static io.harness.rule.OwnerRule.BOGDAN;
@@ -74,6 +75,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -298,6 +300,7 @@ public class GkeClusterHelperTest extends CategoryTest {
     when(gcpHelperService.getGoogleCredential(eq(DUMMY_GCP_KEY_CHARS), eq(false))).thenReturn(creds);
     MockedStatic mockedStaticAuthPlugin = mockStatic(KubeConfigAuthPluginHelper.class);
     when(KubeConfigAuthPluginHelper.isExecAuthPluginBinaryAvailable(any(), any())).thenReturn(false);
+    when(KubeConfigAuthPluginHelper.runCommand(any(), any(), any())).thenReturn(true);
 
     // when
     KubernetesConfig config = gkeClusterHelper.getCluster(DUMMY_GCP_KEY.toCharArray(), false, ZONE_CLUSTER, "default");
@@ -476,6 +479,7 @@ public class GkeClusterHelperTest extends CategoryTest {
     when(gcpHelperService.getGoogleCredential(eq(DUMMY_GCP_KEY_CHARS), eq(false))).thenReturn(creds);
     MockedStatic mockedStaticAuthPlugin = mockStatic(KubeConfigAuthPluginHelper.class);
     when(KubeConfigAuthPluginHelper.isExecAuthPluginBinaryAvailable(any(), any())).thenReturn(true);
+    when(KubeConfigAuthPluginHelper.runCommand(any(), any(), any())).thenReturn(true);
 
     // when
     KubernetesConfig config = gkeClusterHelper.getCluster(DUMMY_GCP_KEY.toCharArray(), false, ZONE_CLUSTER, "default");
@@ -488,6 +492,7 @@ public class GkeClusterHelperTest extends CategoryTest {
         .isEqualTo(Exec.builder()
                        .command(GCP_AUTH_PLUGIN_BINARY)
                        .apiVersion(API_VERSION)
+                       .args(Collections.singletonList(GOOGLE_APPLICATION_CREDENTIALS_FLAG))
                        .installHint(GCP_AUTH_PLUGIN_INSTALL_HINT)
                        .provideClusterInfo(true)
                        .interactiveMode(InteractiveMode.NEVER)
@@ -516,6 +521,7 @@ public class GkeClusterHelperTest extends CategoryTest {
     when(gcpHelperService.getGoogleCredential(eq(DUMMY_GCP_KEY_CHARS), eq(false))).thenReturn(creds);
     MockedStatic mockedStaticAuthPlugin = mockStatic(KubeConfigAuthPluginHelper.class);
     when(KubeConfigAuthPluginHelper.isExecAuthPluginBinaryAvailable(any(), any())).thenReturn(true);
+    when(KubeConfigAuthPluginHelper.runCommand(any(), any(), any())).thenReturn(true);
 
     // when
     KubernetesConfig config = gkeClusterHelper.getCluster(DUMMY_GCP_KEY.toCharArray(), false, ZONE_CLUSTER, "default");
@@ -529,6 +535,7 @@ public class GkeClusterHelperTest extends CategoryTest {
         .isEqualTo(Exec.builder()
                        .command(GCP_AUTH_PLUGIN_BINARY)
                        .apiVersion(API_VERSION)
+                       .args(Collections.singletonList(GOOGLE_APPLICATION_CREDENTIALS_FLAG))
                        .installHint(GCP_AUTH_PLUGIN_INSTALL_HINT)
                        .provideClusterInfo(true)
                        .interactiveMode(InteractiveMode.NEVER)

--- a/930-delegate-tasks/src/test/java/io/harness/delegate/task/k8s/ContainerDeploymentDelegateBaseHelperTest.java
+++ b/930-delegate-tasks/src/test/java/io/harness/delegate/task/k8s/ContainerDeploymentDelegateBaseHelperTest.java
@@ -194,6 +194,7 @@ public class ContainerDeploymentDelegateBaseHelperTest extends CategoryTest {
 
     MockedStatic kubeConfigAuthPluginHelper = mockStatic(KubeConfigAuthPluginHelper.class);
     Mockito.when(KubeConfigAuthPluginHelper.isExecAuthPluginBinaryAvailable(any(), any())).thenReturn(true);
+    when(KubeConfigAuthPluginHelper.runCommand(any(), any(), any())).thenReturn(true);
     KubernetesConfig expectedKubernetesConfig = KubernetesConfig.builder().password(secret).build();
     doReturn(expectedKubernetesConfig)
         .when(gkeClusterHelper)
@@ -225,6 +226,7 @@ public class ContainerDeploymentDelegateBaseHelperTest extends CategoryTest {
 
     MockedStatic kubeConfigAuthPluginHelper = mockStatic(KubeConfigAuthPluginHelper.class);
     Mockito.when(KubeConfigAuthPluginHelper.isExecAuthPluginBinaryAvailable(any(), any())).thenReturn(true);
+    when(KubeConfigAuthPluginHelper.runCommand(any(), any(), any())).thenReturn(true);
 
     KubernetesConfig expectedKubernetesConfig = KubernetesConfig.builder().username("test".toCharArray()).build();
     doReturn(expectedKubernetesConfig)
@@ -368,6 +370,7 @@ public class ContainerDeploymentDelegateBaseHelperTest extends CategoryTest {
     final KubernetesConfig kubernetesConfig = KubernetesConfig.builder().build();
     MockedStatic kubeConfigAuthPluginHelper = mockStatic(KubeConfigAuthPluginHelper.class);
     Mockito.when(KubeConfigAuthPluginHelper.isExecAuthPluginBinaryAvailable(any(), any())).thenReturn(true);
+    when(KubeConfigAuthPluginHelper.runCommand(any(), any(), any())).thenReturn(true);
     doReturn(kubernetesConfig)
         .when(gkeClusterHelper)
         .getCluster(serviceAccountKeyFileContent, false, "cluster", "default", null);

--- a/960-api-services/src/main/java/io/harness/azurecli/AzureCliClient.java
+++ b/960-api-services/src/main/java/io/harness/azurecli/AzureCliClient.java
@@ -8,8 +8,6 @@
 package io.harness.azurecli;
 
 import static io.harness.azure.model.AzureConstants.AZURE_CLI_CMD;
-import static io.harness.azure.model.AzureConstants.AZURE_CONFIG_DIR;
-import static io.harness.azure.model.AzureConstants.AZURE_LOGIN_CONFIG_DIR_PATH;
 import static io.harness.k8s.kubectl.Utils.encloseWithQuotesIfNeeded;
 
 import io.harness.azure.model.AzureAuthenticationType;
@@ -19,7 +17,6 @@ import io.harness.exception.NestedExceptionUtils;
 import io.harness.k8s.model.kubeconfig.KubeConfigAuthPluginHelper;
 import io.harness.logging.LogCallback;
 
-import java.nio.file.Paths;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 
@@ -65,8 +62,6 @@ public class AzureCliClient {
     String azureCliClientVersionCommand = AzureCliClient.client(AZURE_CLI_CMD).version().command();
     if (KubeConfigAuthPluginHelper.runCommand(azureCliClientVersionCommand, logCallback, env)
         && StringUtils.isNotEmpty(workingDirectory)) {
-      env.put(AZURE_CONFIG_DIR,
-          Paths.get(workingDirectory, AZURE_LOGIN_CONFIG_DIR_PATH).normalize().toAbsolutePath().toString());
       boolean isAzureCliInstalled =
           KubeConfigAuthPluginHelper.runCommand(getAuthCommand(azureConfig), logCallback, env);
       if (!isAzureCliInstalled) {

--- a/960-api-services/src/main/java/io/harness/shell/ScriptProcessExecutor.java
+++ b/960-api-services/src/main/java/io/harness/shell/ScriptProcessExecutor.java
@@ -7,6 +7,7 @@
 
 package io.harness.shell;
 
+import static io.harness.azure.model.AzureConstants.AZURE_LOGIN_CONFIG_DIR_PATH;
 import static io.harness.data.structure.EmptyPredicate.isEmpty;
 import static io.harness.data.structure.EmptyPredicate.isNotEmpty;
 import static io.harness.filesystem.FileIo.createDirectoryIfDoesNotExist;
@@ -43,6 +44,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.Collections;
 import java.util.HashMap;
@@ -158,6 +160,10 @@ public class ScriptProcessExecutor extends AbstractScriptExecutor {
         } else {
           deleteFileIfExists(scriptFile.getAbsolutePath());
           deleteFileIfExists(kubeConfigFile.getAbsolutePath());
+          deleteDirectoryAndItsContentIfExists(Paths.get(String.valueOf(workingDirectory), AZURE_LOGIN_CONFIG_DIR_PATH)
+                                                   .normalize()
+                                                   .toAbsolutePath()
+                                                   .toString());
           if (gcpKeyFile.isPresent()) {
             deleteFileIfExists(gcpKeyFile.get().toAbsolutePath().toString());
           }
@@ -364,6 +370,10 @@ public class ScriptProcessExecutor extends AbstractScriptExecutor {
       } else {
         deleteFileIfExists(scriptFile.getAbsolutePath());
         deleteFileIfExists(kubeConfigFile.getAbsolutePath());
+        deleteDirectoryAndItsContentIfExists(Paths.get(String.valueOf(workingDirectory), AZURE_LOGIN_CONFIG_DIR_PATH)
+                                                 .normalize()
+                                                 .toAbsolutePath()
+                                                 .toString());
         if (envVariablesOutputFile != null) {
           deleteFileIfExists(envVariablesOutputFile.getAbsolutePath());
         }

--- a/970-api-services-beans/src/main/java/io/harness/k8s/K8sConstants.java
+++ b/970-api-services-beans/src/main/java/io/harness/k8s/K8sConstants.java
@@ -196,6 +196,7 @@ public interface K8sConstants {
 
   String AZURE_AUTH_PLUGIN_BINARY = "kubelogin";
   String GCP_AUTH_PLUGIN_BINARY = "gke-gcloud-auth-plugin";
+  String GOOGLE_APPLICATION_CREDENTIALS_FLAG = "--use_application_default_credentials";
   String GCP_AUTH_PLUGIN_INSTALL_HINT = "gke-gcloud-auth-plugin is required to authenticate to the current cluster.\n"
       + "It can be installed on the delegate using following command from:\n"
       + "https://cloud.google.com/sdk/docs/install#rpm\n"


### PR DESCRIPTION
* feat: [CDS-58438]: Login to the cluster before executing the kubeconfig file.

* feat: [CDS-58438]: adding GOOGLE APPLICATIONS CREDENTIALS.

* feat: [CDS-58438]: setting AZURE_CONFIG_DIR for all auth types.

* feat: [CDS-58438]: fixing UT's

* feat: [CDS-58438]: fixing UT's