### PR TITLE
fix:[CDS-59510]: Review stats collector for instance documents (#47174)

### DIFF
--- a/400-rest/src/main/java/software/wings/service/impl/instance/stats/collector/InstanceMapperConsumer.java
+++ b/400-rest/src/main/java/software/wings/service/impl/instance/stats/collector/InstanceMapperConsumer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package software.wings.service.impl.instance.stats.collector;
+
+import software.wings.beans.EntityType;
+import software.wings.beans.infrastructure.instance.Instance;
+import software.wings.beans.infrastructure.instance.stats.InstanceStatsSnapshot;
+import software.wings.beans.infrastructure.instance.stats.InstanceStatsSnapshot.AggregateCount;
+import software.wings.beans.infrastructure.instance.stats.Mapper;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import lombok.AllArgsConstructor;
+
+/**
+ * At the end, work in the same way as {@link InstanceMapper}. However, instead of receive a collection and iterate over
+ * it, the class act as a consumer of {@link Instance} and aggregate data on the fly during the {@link
+ * io.harness.persistence.HIterator} operation.
+ *
+ * @see software.wings.service.impl.instance.DashboardStatisticsServiceImpl#consumeAppInstancesForAccount(String, long,
+ *     Consumer)
+ */
+@AllArgsConstructor
+class InstanceMapperConsumer implements Mapper<Collection<Instance>, InstanceStatsSnapshot>, Consumer<Instance> {
+  private Instant instant;
+  private String accountId;
+
+  private final Map<String, AggregateCount> appCounts = new HashMap<>();
+
+  @Override
+  public InstanceStatsSnapshot map(Collection<Instance> instances) {
+    List<AggregateCount> aggregateCounts = new ArrayList<>(appCounts.values());
+
+    return new InstanceStatsSnapshot(instant, accountId, aggregateCounts);
+  }
+
+  @Override
+  public void accept(Instance instance) {
+    AggregateCount appCount = appCounts.computeIfAbsent(instance.getAppId(),
+        appId -> new AggregateCount(EntityType.APPLICATION, instance.getAppName(), instance.getAppId(), 0));
+    appCount.incrementCount(1);
+  }
+}

--- a/400-rest/src/main/java/software/wings/service/intfc/instance/DashboardStatisticsService.java
+++ b/400-rest/src/main/java/software/wings/service/intfc/instance/DashboardStatisticsService.java
@@ -26,6 +26,7 @@ import software.wings.service.impl.instance.CompareEnvironmentAggregationRespons
 
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 import org.hibernate.validator.constraints.NotEmpty;
 
@@ -82,6 +83,13 @@ public interface DashboardStatisticsService {
    */
   @Nonnull List<Instance> getAppInstancesForAccount(@NotEmpty String accountId, long timestamp);
 
+  /**
+   * Search instances for the given account. This API is used by the stats cron job.
+   *
+   * @return total of retrieved instances
+   */
+  int consumeAppInstancesForAccount(@NotEmpty String accountId, long timestamp, Consumer<Instance> instanceConsumer);
+
   List<InstanceStatsByEnvironment> getServiceInstances(String accountId, String serviceId, long timestamp);
 
   PageResponse<InstanceSummaryStatsByService> getAppInstanceSummaryStatsByService(
@@ -113,4 +121,6 @@ public interface DashboardStatisticsService {
 
   ServiceInstanceDashboard getServiceInstanceDashboardFiltered(
       String accountId, String appId, String serviceId, PageRequest<WorkflowExecution> pageRequest);
+
+  boolean isInstanceConsumerEnabled(String accountId);
 }

--- a/400-rest/src/test/java/software/wings/service/impl/instance/stats/collector/InstanceMapperConsumerTest.java
+++ b/400-rest/src/test/java/software/wings/service/impl/instance/stats/collector/InstanceMapperConsumerTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package software.wings.service.impl.instance.stats.collector;
+
+import static io.harness.rule.OwnerRule.FERNANDOD;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.harness.category.element.UnitTests;
+import io.harness.rule.Owner;
+
+import software.wings.beans.EntityType;
+import software.wings.beans.infrastructure.instance.Instance;
+import software.wings.beans.infrastructure.instance.stats.InstanceStatsSnapshot;
+
+import com.google.common.base.Suppliers;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Value;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+public class InstanceMapperConsumerTest {
+  @Value
+  @AllArgsConstructor
+  static class App {
+    private String appId;
+    private String appName;
+  }
+
+  private Supplier<List<InstanceMapperTest.App>> sampleApps = Suppliers.memoize(
+      ()
+          -> Arrays.asList(
+              new InstanceMapperTest.App(RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5)),
+              new InstanceMapperTest.App(
+                  RandomStringUtils.randomAlphabetic(5), RandomStringUtils.randomAlphabetic(5))));
+
+  @Test
+  @Owner(developers = FERNANDOD)
+  @Category(UnitTests.class)
+  public void testMapping() {
+    Instant ts = Instant.now();
+    String accountId = "some-account-id";
+    InstanceMapperConsumer mapper = new InstanceMapperConsumer(ts, accountId);
+
+    List<Instance> instances = getSampleInstance(accountId);
+    instances.forEach(mapper);
+    InstanceStatsSnapshot statsSnapshot = mapper.map(instances);
+
+    assertThat(statsSnapshot.getTimestamp()).isEqualTo(ts);
+    assertThat(statsSnapshot.getAccountId()).isEqualTo(accountId);
+    assertThat(statsSnapshot.getTotal()).isEqualTo(instances.size());
+    assertThat(statsSnapshot.getAggregateCounts()).hasSize(2);
+    assertThat(
+        statsSnapshot.getAggregateCounts().stream().filter(s -> s.getEntityType() == EntityType.APPLICATION).count())
+        .isEqualTo(2);
+
+    List<InstanceMapperTest.App> apps = statsSnapshot.getAggregateCounts()
+                                            .stream()
+                                            .filter(it -> it.getEntityType() == EntityType.APPLICATION)
+                                            .map(it -> new InstanceMapperTest.App(it.getId(), it.getName()))
+                                            .collect(Collectors.toList());
+
+    assertThat(apps.containsAll(sampleApps.get())).isTrue();
+    assertThat(
+        statsSnapshot.getAggregateCounts().stream().filter(it -> it.getEntityType() == EntityType.SERVICE).count())
+        .isEqualTo(0);
+  }
+
+  @Test
+  @Owner(developers = FERNANDOD)
+  @Category(UnitTests.class)
+  public void testMappingWithEmptySet() {
+    Instant ts = Instant.now();
+    String accountId = "some-account-id";
+    InstanceMapperConsumer mapper = new InstanceMapperConsumer(ts, accountId);
+
+    List<Instance> instances = Collections.emptyList();
+    InstanceStatsSnapshot statsSnapshot = mapper.map(instances);
+
+    assertThat(statsSnapshot.getTimestamp()).isEqualTo(ts);
+    assertThat(statsSnapshot.getAccountId()).isEqualTo(accountId);
+    assertThat(statsSnapshot.getTotal()).isEqualTo(instances.size());
+    assertThat(statsSnapshot.getAggregateCounts()).isEmpty();
+    assertThat(
+        statsSnapshot.getAggregateCounts().stream().filter(it -> it.getEntityType() == EntityType.APPLICATION).count())
+        .isEqualTo(0);
+
+    List<InstanceMapperTest.App> apps = statsSnapshot.getAggregateCounts()
+                                            .stream()
+                                            .filter(it -> it.getEntityType() == EntityType.APPLICATION)
+                                            .map(it -> new InstanceMapperTest.App(it.getId(), it.getName()))
+                                            .collect(Collectors.toList());
+
+    assertThat(apps.isEmpty()).isTrue();
+    assertThat(
+        statsSnapshot.getAggregateCounts().stream().filter(it -> it.getEntityType() == EntityType.SERVICE).count())
+        .isEqualTo(0);
+  }
+
+  private List<Instance> getSampleInstance(String accountId) {
+    return sampleApps.get()
+        .stream()
+        .map(it
+            -> Instance.builder()
+                   .accountId(accountId)
+                   .appId(it.getAppId())
+                   .appName(it.getAppName())
+                   .serviceId("some-service-id")
+                   .serviceName("some-service-name")
+                   .build())
+        .collect(Collectors.toList());
+  }
+}

--- a/956-feature-flag-beans/src/main/java/io/harness/beans/FeatureName.java
+++ b/956-feature-flag-beans/src/main/java/io/harness/beans/FeatureName.java
@@ -23,6 +23,7 @@ import lombok.Getter;
 @OwnedBy(HarnessTeam.PL)
 public enum FeatureName {
   SPG_UI_ALLOW_ENCODING_FOR_JENKINS_ARTIFACT("Enables correct encoding for jenkins artifact", HarnessTeam.SPG),
+  SPG_CG_STATS_INSTANCE_CONSUMER("Optimize stats collector for instance collection", HarnessTeam.SPG),
   SPG_HTTP_STEP_CERTIFICATE("Allow enforce SSL/TLS certificate in HTTP step", HarnessTeam.SPG),
   SPG_GRAPHQL_VERIFY_APPLICATION_FROM_USER_GROUP(
       "Verify if application references from a user group still exist", HarnessTeam.SPG),


### PR DESCRIPTION
* fix:[CDS-59510]: Added back an else condition

The else condition was removed during a refactor made by commit f156fe38341ce92a98a5bd9f3e5696b0a5d7bc97

* fix:[CDS-59510]: Review stats collector for instance documents

Add HIterator when executing query to avoid retrieving all documents to the memory, using a consumer strategy to process each retrieved document and keep the current business behavior.

* fix:[CDS-59510]: Keep the same behavior between consumeInstancesForAccount and getInstancesForAccount