### PR TITLE
feat: [CDS-67674]: Multi Select in Allowed Values type runtime input and allow comma in the allowed values strings. (#47083)

### DIFF
--- a/125-cd-nextgen/src/test/java/io/harness/cdng/infra/steps/InfrastructureTaskExecutableStepV2Test.java
+++ b/125-cd-nextgen/src/test/java/io/harness/cdng/infra/steps/InfrastructureTaskExecutableStepV2Test.java
@@ -403,7 +403,7 @@ public class InfrastructureTaskExecutableStepV2Test extends CategoryTest {
                                 .build(),
                             null))
         .withMessageContaining(
-            "The value provided for [infrastructureDefinition.spec.credentialsRef: prod] does not match any of the allowed values [dev,qa]");
+            "The values provided for infrastructureDefinition.spec.credentialsRef: [\\'prod\\'] do not match any of the allowed values [\\'dev\\', \\'qa\\']");
   }
 
   @Test

--- a/125-cd-nextgen/src/test/java/io/harness/cdng/service/steps/ServiceStepV3Test.java
+++ b/125-cd-nextgen/src/test/java/io/harness/cdng/service/steps/ServiceStepV3Test.java
@@ -611,7 +611,7 @@ public class ServiceStepV3Test extends CategoryTest {
                                 .build(),
                             null))
         .withMessageContaining(
-            "The value provided for [environment.variables.numbervar: 7] does not match any of the allowed values [5,6]");
+            "The values provided for environment.variables.numbervar: [\\'7\\'] do not match any of the allowed values [\\'5\\', \\'6\\']");
   }
   @Test
   @Owner(developers = OwnerRule.ROHITKARELIA)

--- a/953-yaml-commons/src/main/java/io/harness/pms/yaml/validation/AllowedValuesHelper.java
+++ b/953-yaml-commons/src/main/java/io/harness/pms/yaml/validation/AllowedValuesHelper.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+package io.harness.pms.yaml.validation;
+
+import io.harness.annotations.dev.HarnessTeam;
+import io.harness.annotations.dev.OwnedBy;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+@OwnedBy(HarnessTeam.PIPELINE)
+public class AllowedValuesHelper {
+  public List<String> split(String input) {
+    List<String> values = new ArrayList<>();
+    int startPosition = 0;
+    boolean isInSingleQuotes = false;
+    boolean isInDoubleQuotes = false;
+
+    for (int currentPosition = 0; currentPosition < input.length(); currentPosition++) {
+      // Checking if the current position has substring \'
+      if (currentPosition + 1 < input.length() && input.charAt(currentPosition) == '\\'
+          && input.charAt(currentPosition + 1) == '\'') {
+        isInSingleQuotes = !isInSingleQuotes;
+      }
+      // Checking if the current position has substring \"
+      else if (currentPosition + 1 < input.length() && input.charAt(currentPosition) == '\\'
+          && input.charAt(currentPosition + 1) == '\"') {
+        isInDoubleQuotes = !isInDoubleQuotes;
+      }
+      // If current char is , and it's not within single or double quotes, then add the substring to the list
+      else if (input.charAt(currentPosition) == ',' && !isInSingleQuotes && !isInDoubleQuotes) {
+        values.add(input.substring(startPosition, currentPosition).trim());
+        startPosition = currentPosition + 1;
+      }
+    }
+
+    // Add last value after the last comma to the list
+    String lastValue = input.substring(startPosition);
+    values.add(lastValue.trim());
+
+    // remove outer quotes from \" ... \" and \' ... \'
+    for (int i = 0; i < values.size(); i++) {
+      if ((values.get(i).startsWith("\\\"") && values.get(i).endsWith("\\\""))
+          || (values.get(i).startsWith("\\'") && values.get(i).endsWith("\\'"))) {
+        values.set(i, values.get(i).substring(2, values.get(i).length() - 2));
+      }
+    }
+    return values;
+  }
+}

--- a/953-yaml-commons/src/test/java/io/harness/pms/yaml/validation/AllowedValuesHelperTest.java
+++ b/953-yaml-commons/src/test/java/io/harness/pms/yaml/validation/AllowedValuesHelperTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+package io.harness.pms.yaml.validation;
+
+import static io.harness.rule.OwnerRule.SHALINI;
+
+import static junit.framework.TestCase.assertEquals;
+
+import io.harness.CategoryTest;
+import io.harness.annotations.dev.HarnessTeam;
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.category.element.UnitTests;
+import io.harness.rule.Owner;
+
+import java.util.List;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@OwnedBy(HarnessTeam.PIPELINE)
+public class AllowedValuesHelperTest extends CategoryTest {
+  @Test
+  @Owner(developers = SHALINI)
+  @Category(UnitTests.class)
+  public void testSplit() {
+    assertEquals(
+        AllowedValuesHelper.split("abc, \\'def, ghi\\', \\\"jkl, mn\\\""), List.of("abc", "def, ghi", "jkl, mn"));
+    assertEquals(AllowedValuesHelper.split("abc's\\xyz, \\'def'm, gh\\i\\', \\\"jkl, mn\\\", \\'mnk"),
+        List.of("abc's\\xyz", "def'm, gh\\i", "jkl, mn", "\\'mnk"));
+  }
+}

--- a/956-feature-flag-beans/src/main/java/io/harness/beans/FeatureName.java
+++ b/956-feature-flag-beans/src/main/java/io/harness/beans/FeatureName.java
@@ -741,7 +741,9 @@ public enum FeatureName {
       HarnessTeam.GTM),
   SPG_TRIGGER_FOR_ALL_ARTIFACTS_NG(
       "Will fire the artifact and manifest triggers for all the versions in the polling response instead of the latest only",
-      HarnessTeam.SPG);
+      HarnessTeam.SPG),
+  PIE_MULTISELECT_AND_COMMA_IN_ALLOWED_VALUES(
+      "Will allow comma and multi-selection in runtime input allowed values", PIPELINE);
 
   @Deprecated
   FeatureName() {

--- a/pipeline-service/service/src/test/java/io/harness/pms/ngpipeline/inputset/helpers/InputSetErrorsHelperTest.java
+++ b/pipeline-service/service/src/test/java/io/harness/pms/ngpipeline/inputset/helpers/InputSetErrorsHelperTest.java
@@ -153,7 +153,7 @@ public class InputSetErrorsHelperTest extends CategoryTest {
     assertThat(oneError).containsKey("pipeline.field2.child1");
     assertThat(oneError.get("pipeline.field2.child1").getErrors().get(0).getMessage())
         .isEqualTo(
-            "The value provided for [pipeline.field2.child1: d] does not match any of the allowed values [a,b,c]");
+            "The values provided for pipeline.field2.child1: [\\'d\\'] do not match any of the allowed values [\\'a\\', \\'b\\', \\'c\\']");
   }
 
   @Test


### PR DESCRIPTION
* feat: [CDS-67674]: Multi Select in Allowed Values type runtime input

* fix

* allow comma in allowed values

* fix splitter to delimit based on comma followed by space between two allowed values

* improve error message

* improve error message

* fix tests

* fix tests

* added UT

* addressed comments