### PR TITLE
feat: [CDS-68225]: Handle final status for AsyncStrategy - added logs (#47130)

### DIFF
--- a/clients/pipeline-service/pms-sdk-core/src/main/java/io/harness/pms/sdk/core/execution/invokers/AsyncStrategy.java
+++ b/clients/pipeline-service/pms-sdk-core/src/main/java/io/harness/pms/sdk/core/execution/invokers/AsyncStrategy.java
@@ -15,7 +15,9 @@ import io.harness.pms.contracts.ambiance.Ambiance;
 import io.harness.pms.contracts.execution.AsyncExecutableResponse;
 import io.harness.pms.contracts.execution.ExecutableResponse;
 import io.harness.pms.contracts.execution.ExecutionMode;
+import io.harness.pms.contracts.execution.Status;
 import io.harness.pms.execution.utils.AmbianceUtils;
+import io.harness.pms.execution.utils.StatusUtils;
 import io.harness.pms.sdk.core.execution.AsyncSdkProgressCallback;
 import io.harness.pms.sdk.core.execution.AsyncSdkResumeCallback;
 import io.harness.pms.sdk.core.execution.AsyncSdkSingleCallback;
@@ -51,6 +53,13 @@ public class AsyncStrategy extends ProgressableStrategy {
     AsyncExecutable asyncExecutable = extractStep(ambiance);
     AsyncExecutableResponse asyncExecutableResponse = asyncExecutable.executeAsync(ambiance,
         invokerPackage.getStepParameters(), invokerPackage.getInputPackage(), invokerPackage.getPassThroughData());
+    // Status should be in non-final state
+    if (!StatusUtils.resumableStatuses().contains(asyncExecutableResponse.getStatus())) {
+      log.warn("Skipping Handle Response as status in AsyncExecutionResponse is of final state {} ",
+          asyncExecutableResponse.getStatus());
+      asyncExecutableResponse = asyncExecutableResponse.toBuilder().setStatus(Status.NO_OP).build();
+    }
+    // This is only for handling non-final state
     handleResponse(
         ambiance, invokerPackage.getExecutionMode(), invokerPackage.getStepParameters(), asyncExecutableResponse);
   }

--- a/pipeline-service/modules/orchestration/src/main/java/io/harness/event/handlers/AddExecutableResponseRequestProcessor.java
+++ b/pipeline-service/modules/orchestration/src/main/java/io/harness/event/handlers/AddExecutableResponseRequestProcessor.java
@@ -10,6 +10,7 @@ package io.harness.event.handlers;
 import io.harness.annotations.dev.HarnessTeam;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.engine.executions.node.NodeExecutionService;
+import io.harness.execution.NodeExecution;
 import io.harness.execution.NodeExecution.NodeExecutionKeys;
 import io.harness.pms.contracts.execution.Status;
 import io.harness.pms.contracts.execution.events.AddExecutableResponseRequest;
@@ -34,11 +35,20 @@ public class AddExecutableResponseRequestProcessor implements SdkResponseProcess
         && request.getExecutableResponse().getAsync().getStatus() != Status.NO_OP) {
       // As override set is empty, this will prevent any race condition as mongo will handle it using
       // StatusUtils.nodeAllowedStartSet()
-      nodeExecutionService.updateStatusWithOps(SdkResponseEventUtils.getNodeExecutionId(event),
-          request.getExecutableResponse().getAsync().getStatus(),
+      NodeExecution nodeExecution = nodeExecutionService.updateStatusWithOps(
+          SdkResponseEventUtils.getNodeExecutionId(event), request.getExecutableResponse().getAsync().getStatus(),
           ops
           -> ops.addToSet(NodeExecutionKeys.executableResponses, request.getExecutableResponse()),
           EnumSet.noneOf(Status.class));
+      // Update of node execution can also fail due to race condition between the status. This will also fail to update
+      // executable response. Hence updating executable response in case failure happended due to race conditon for
+      // status
+      if (nodeExecution == null) {
+        log.info("Update NodeExecution failed for status - {}, updating only executable Response",
+            request.getExecutableResponse().getAsync().getStatus());
+        nodeExecutionService.update(SdkResponseEventUtils.getNodeExecutionId(event),
+            ops -> ops.addToSet(NodeExecutionKeys.executableResponses, request.getExecutableResponse()));
+      }
     } else {
       nodeExecutionService.updateV2(SdkResponseEventUtils.getNodeExecutionId(event),
           ops -> ops.addToSet(NodeExecutionKeys.executableResponses, request.getExecutableResponse()));

--- a/pipeline-service/modules/orchestration/src/test/java/io/harness/event/handlers/AddExecutableResponseRequestProcessorTest.java
+++ b/pipeline-service/modules/orchestration/src/test/java/io/harness/event/handlers/AddExecutableResponseRequestProcessorTest.java
@@ -102,5 +102,6 @@ public class AddExecutableResponseRequestProcessorTest extends CategoryTest {
             .build());
     verify(nodeExecutionService)
         .updateStatusWithOps(eq(nodeExecutionId), eq(Status.QUEUED_LICENSE_LIMIT_REACHED), any(), any());
+    verify(nodeExecutionService).update(eq(nodeExecutionId), any());
   }
 }

--- a/pipeline-service/modules/pms-contracts/src/main/proto/io/harness/pms/contracts/execution/executable_response.proto
+++ b/pipeline-service/modules/pms-contracts/src/main/proto/io/harness/pms/contracts/execution/executable_response.proto
@@ -35,7 +35,8 @@ message AsyncExecutableResponse {
   repeated string logKeys = 2;
   repeated string units = 3;
   int32 timeout = 5;
-  Status status = 9;  // Async step can send the status they want to set for their step
+  Status status = 9;  // Async step can send the status they want to set for their step. This status is only for
+                      // non-final status (StatusUtils.RESUMABLE_STATUSES())
 }
 
 message ChildExecutableResponse {


### PR DESCRIPTION
* feat: [CDS-68225]: Handle final status for AsyncStrategy - added logs

* feat: [CDS-68225]: override status

* feat: [CDS-68225]: verify(nodeExecutionService)
        .updateStatusWithOps(eq(nodeExecutionId), eq(Status.QUEUED_LICENSE_LIMIT_REACHED), any(), any());