### PR TITLE
feat: [PLG-2125]: Add support for ChaosEngineering version in release notes (#47032)

### DIFF
--- a/120-ng-manager/src/main/java/io/harness/ng/moduleversioninfo/runnable/UpdateVersionInfoTask.java
+++ b/120-ng-manager/src/main/java/io/harness/ng/moduleversioninfo/runnable/UpdateVersionInfoTask.java
@@ -51,6 +51,7 @@ public class UpdateVersionInfoTask {
   private static final String COMING_SOON = "Coming Soon";
   private static final String VERSION = "version";
   private static final String JOB_INTERRUPTED = "UpdateVersionInfoTask Sync job was interrupted due to: ";
+  public static final String CHAOS_MANAGER_API = "manager/api/";
   @Inject private MongoTemplate mongoTemplate;
   @Inject NextGenConfiguration nextGenConfiguration;
   List<ModuleVersionInfo> moduleVersionInfos;
@@ -95,6 +96,11 @@ public class UpdateVersionInfoTask {
       return nextGenConfiguration.getCiManagerClientConfig().getBaseUrl();
     } else if (ModuleType.SRM.name().equals(moduleName)) {
       return nextGenConfiguration.getCvngClientConfig().getBaseUrl();
+    } else if (ModuleType.CHAOS.name().equalsIgnoreCase(moduleName)) {
+      StringBuilder chaosManagerUrl = new StringBuilder();
+      chaosManagerUrl.append(nextGenConfiguration.getChaosServiceClientConfig().getBaseUrl()).append(CHAOS_MANAGER_API);
+
+      return chaosManagerUrl.toString();
     } else {
       return "";
     }

--- a/120-ng-manager/src/main/resources/mvi/baseinfo.json
+++ b/120-ng-manager/src/main/resources/mvi/baseinfo.json
@@ -30,6 +30,16 @@
      ]
    },
    {
+     "moduleName": "CHAOS",
+     "displayName": "Chaos Engineering",
+     "version": "",
+     "lastModifiedAt": "",
+     "versionUrl": "",
+     "releaseNotesLink": "https://developer.harness.io/release-notes/chaos-engineering",
+     "microservicesVersionInfo": [
+     ]
+   },
+   {
      "moduleName": "FF",
      "displayName": "Feature Flags",
      "version": "Coming Soon",


### PR DESCRIPTION
* feat: [PLG-2125]: Add support for ChaosEngineering version in release notes

Adding support for showing the version number of Chaos Manager in Release Notes.

* feat: [PLG-2125]: updating the chaosManagerUrl

* feat: [PLG-2125]: adding ignoreCase for moduleName

* feat: [PLG-2125]: refactoring