### PR TITLE
fix: [CDS-68657]: add handling for runtime exception in winrm executor (#47240)

### DIFF
--- a/930-delegate-tasks/src/main/java/io/harness/delegate/task/winrm/DefaultWinRmExecutor.java
+++ b/930-delegate-tasks/src/main/java/io/harness/delegate/task/winrm/DefaultWinRmExecutor.java
@@ -145,6 +145,11 @@ public class DefaultWinRmExecutor implements WinRmExecutor {
       WinRmExecutorHelper.cleanupFiles(
           session, psScriptFile, powershell, disableCommandEncoding, config.getCommandParameters());
     } catch (RuntimeException re) {
+      commandExecutionStatus = FAILURE;
+      log.error(ERROR_WHILE_EXECUTING_COMMAND, re);
+      ResponseMessage details = buildErrorDetailsFromWinRmClientException(re);
+      saveExecutionLog(
+          format("Command execution failed. Error: %s", details.getMessage()), ERROR, commandExecutionStatus);
       throw re;
     } catch (Exception e) {
       commandExecutionStatus = FAILURE;


### PR DESCRIPTION
* fix: [CDS-68657]: add handling for runtime exception in winrm executor

* fix config delegate