### PR TITLE
fix: [CDS-68641]: K8s Canary - only consider versioned configmaps/secrets for deletion (#47348)

### DIFF
--- a/930-delegate-tasks/src/test/java/io/harness/delegate/k8s/K8sCanaryBaseHandlerTest.java
+++ b/930-delegate-tasks/src/test/java/io/harness/delegate/k8s/K8sCanaryBaseHandlerTest.java
@@ -12,6 +12,8 @@ import static io.harness.delegate.k8s.K8sTestConstants.CONFIG_MAP_YAML;
 import static io.harness.delegate.k8s.K8sTestConstants.DAEMON_SET_YAML;
 import static io.harness.delegate.k8s.K8sTestConstants.DEPLOYMENT_YAML;
 import static io.harness.delegate.k8s.K8sTestConstants.SECRET_YAML;
+import static io.harness.delegate.k8s.K8sTestConstants.SKIP_VERSIONING_CONFIG_MAP_YAML;
+import static io.harness.delegate.k8s.K8sTestConstants.SKIP_VERSIONING_SECRET_YAML;
 import static io.harness.k8s.releasehistory.IK8sRelease.Status.Failed;
 import static io.harness.k8s.releasehistory.IK8sRelease.Status.InProgress;
 import static io.harness.k8s.releasehistory.K8sReleaseConstants.RELEASE_NUMBER_LABEL_KEY;
@@ -476,6 +478,13 @@ public class K8sCanaryBaseHandlerTest extends CategoryTest {
     assertThat(k8sCanaryBaseHandler.appendSecretAndConfigMapNamesToCanaryWorkloads(
                    "test", List.of(kubernetesResources.get(2))))
         .isEqualTo("test");
+
+    kubernetesResources.addAll(ManifestHelper.processYaml(SKIP_VERSIONING_CONFIG_MAP_YAML));
+    kubernetesResources.addAll(ManifestHelper.processYaml(SKIP_VERSIONING_SECRET_YAML));
+
+    canaryResources =
+        k8sCanaryBaseHandler.appendSecretAndConfigMapNamesToCanaryWorkloads("ns/Deployment/test", kubernetesResources);
+    assertThat(canaryResources).isEqualTo("ns/Deployment/test,ns/ConfigMap/mycm,ns/Secret/mysecret");
   }
 
   private void assertInvalidWorkloadsInManifest(boolean result, String expectedMessage) throws Exception {

--- a/930-delegate-tasks/src/test/java/io/harness/delegate/k8s/K8sTestConstants.java
+++ b/930-delegate-tasks/src/test/java/io/harness/delegate/k8s/K8sTestConstants.java
@@ -144,14 +144,32 @@ public final class K8sTestConstants {
       + "data:\n"
       + "  hello: world";
 
+  public static String SKIP_VERSIONING_CONFIG_MAP_YAML = "apiVersion: v1\n"
+      + "kind: ConfigMap\n"
+      + "metadata:\n"
+      + "  name: mycm-sv\n"
+      + "  annotations:\n"
+      + "    harness.io/skip-versioning: true\n"
+      + "data:\n"
+      + "  hello: world";
+
   public static String SECRET_YAML = "apiVersion: v1\n"
       + "kind: Secret\n"
       + "metadata:\n"
       + "  name: mysecret\n"
       + "type: Opaque\n"
-      + "data:\n"
-      + "  username: YWRtaW4=\n"
-      + "  password: MWYyZDFlMmU2N2Rm";
+      + "stringData:\n"
+      + "  a: b\n";
+
+  public static String SKIP_VERSIONING_SECRET_YAML = "apiVersion: v1\n"
+      + "kind: Secret\n"
+      + "metadata:\n"
+      + "  name: mysecret-sv\n"
+      + "  annotations:\n"
+      + "    harness.io/skip-versioning: true\n"
+      + "type: Opaque\n"
+      + "stringData:\n"
+      + "  a: b\n";
 
   private K8sTestConstants() {
     throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");


### PR DESCRIPTION
* fix: [CDS-68641]: K8s Canary - only consider versioned configmaps/secrets for deletion

* fix: [CDS-68641]: remove unused import and resolve false positive for gitleaks check

* fix: [CDS-68641]: remove redundant encoded value from test