### PR TITLE
[fix]: [cds-59271]: Throw exception when project id is passed with environment at org or account  level (#47285)

### DIFF
--- a/127-cd-nextgen-entities/src/test/java/io/harness/ng/core/serviceoverride/mapper/ServiceOverrideMapperTest.java
+++ b/127-cd-nextgen-entities/src/test/java/io/harness/ng/core/serviceoverride/mapper/ServiceOverrideMapperTest.java
@@ -7,14 +7,17 @@
 
 package io.harness.ng.core.serviceoverride.mapper;
 
+import static io.harness.rule.OwnerRule.LOVISH_BANSAL;
 import static io.harness.rule.OwnerRule.PRASHANTSHARMA;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.harness.annotations.dev.HarnessTeam;
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.category.element.UnitTests;
 import io.harness.ng.core.NGCoreTestBase;
+import io.harness.ng.core.serviceoverride.beans.ServiceOverrideRequestDTO;
 import io.harness.rule.Owner;
 import io.harness.yaml.core.variables.NGServiceOverrides;
 
@@ -37,5 +40,19 @@ public class ServiceOverrideMapperTest extends NGCoreTestBase {
     NGServiceOverrides ngServiceOverrides = ServiceOverridesMapper.toServiceOverrides(yaml);
 
     assertThat(ngServiceOverrides.getServiceRef()).isNotNull();
+  }
+
+  @Test
+  @Owner(developers = LOVISH_BANSAL)
+  @Category(UnitTests.class)
+  public void toServiceOverridesThrowsExceptionIfEnvIDIsNotProjectLevel() {
+    ServiceOverrideRequestDTO serviceOverrideRequestDTO = ServiceOverrideRequestDTO.builder()
+                                                              .environmentIdentifier("org.env")
+                                                              .projectIdentifier("projectIdentifier")
+                                                              .orgIdentifier("orgIdentifier")
+                                                              .build();
+    assertThatThrownBy(() -> ServiceOverridesMapper.toServiceOverridesEntity("accountId", serviceOverrideRequestDTO))
+        .hasMessageContaining(
+            "Project Identifier should not be passed when environment used in service override is at organisation or account scope");
   }
 }


### PR DESCRIPTION
* [fix]: [cds-59271]: throw exception when project id is passed with envs at org or account  level

* [fix]: [cds-59271]: throw exception when project id is passed with envs at org or account  level - 2

* [fix]: [cds-59271]: throw exception when project id is passed with envs at org or account  level - 3