### PR TITLE
[fix]: [PL-26474]: Updates secret list api to return forbidden if principal is not having view permission on any of the secret (#47362)

### DIFF
--- a/890-sm-core/src/main/java/io/harness/ng/core/api/NGSecretServiceV2.java
+++ b/890-sm-core/src/main/java/io/harness/ng/core/api/NGSecretServiceV2.java
@@ -16,7 +16,6 @@ import io.harness.ng.core.models.Secret;
 import io.harness.ng.core.remote.SecretValidationMetaData;
 import io.harness.ng.core.remote.SecretValidationResultDTO;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -46,7 +45,7 @@ public interface NGSecretServiceV2 {
 
   Page<Secret> list(Criteria criteria, Pageable pageable);
 
-  List<Secret> getPermitted(Collection<Secret> secrets);
+  List<Secret> getPermitted(List<Secret> secrets);
 
   Page<Secret> getPaginatedResult(List<Secret> unpagedSecrets, int page, int size);
 


### PR DESCRIPTION
* [fix]: [PL-26474]: Updates secret list api to return forbidden if principal is not having view permission on any of the secret

* [fix]: [PL-26474]: Adds unit test for access control client's checkForAccessOrThrow usage for secret access check

* [fix]: [PL-26474]: Minor refactoring by inlining checkAccess method

* [fix]: [PL-26474]: Adds unit test for exception while doing access check