### PR TITLE
[fix]: [PL-32038]: Fixing NullPointerException in user invite flow (#46930)

### DIFF
--- a/960-ng-core-beans/src/main/java/io/harness/ng/core/user/AddUsersDTO.java
+++ b/960-ng-core-beans/src/main/java/io/harness/ng/core/user/AddUsersDTO.java
@@ -8,6 +8,7 @@
 package io.harness.ng.core.user;
 
 import static io.harness.annotations.dev.HarnessTeam.PL;
+import static io.harness.data.structure.EmptyPredicate.isEmpty;
 
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.ng.core.invites.dto.RoleBinding;
@@ -15,6 +16,7 @@ import io.harness.ng.core.invites.dto.RoleBinding;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
 import java.util.List;
 import javax.validation.constraints.Size;
 import lombok.AccessLevel;
@@ -33,4 +35,11 @@ public class AddUsersDTO {
   @ApiModelProperty(required = true) @NotEmpty @Size(max = 100) List<String> emails;
   List<RoleBinding> roleBindings;
   List<String> userGroups;
+
+  public List<RoleBinding> getRoleBindings() {
+    if (isEmpty(roleBindings)) {
+      return new ArrayList<>();
+    }
+    return roleBindings;
+  }
 }


### PR DESCRIPTION
* [fix]: [PL-32038]: Marks role binding field as @NotNull in add user api request body

* [fix]: [PL-32038]: Removes @NotNull from roleBindings in AddUsersDTO and defaults to empty list