### PR TITLE
[feat]: [PL-32216] : Multiple SAML setting 'update', 'delete', 'test' support in NG (#47321)

### DIFF
--- a/122-ng-authentication-settings/src/main/java/io/harness/ng/authenticationsettings/dtos/mechanisms/SAMLSettings.java
+++ b/122-ng-authentication-settings/src/main/java/io/harness/ng/authenticationsettings/dtos/mechanisms/SAMLSettings.java
@@ -37,6 +37,7 @@ public class SAMLSettings extends NGAuthSettings {
   private String clientId;
   private String clientSecret;
   private String friendlySamlName;
+  private Boolean authenticationEnabled;
 
   public SAMLSettings(@JsonProperty("origin") String origin, @JsonProperty("identifier") String identifier,
       @JsonProperty("logoutUrl") String logoutUrl, @JsonProperty("groupMembershipAttr") String groupMembershipAttr,
@@ -44,7 +45,8 @@ public class SAMLSettings extends NGAuthSettings {
       @JsonProperty("authorizationEnabled") Boolean authorizationEnabled,
       @JsonProperty("entityIdentifier") String entityIdentifier,
       @JsonProperty("samlProviderType") String samlProviderType, @JsonProperty("clientId") String clientId,
-      @JsonProperty("clientSecret") String clientSecret, @JsonProperty("friendlySamlName") String friendlySamlName) {
+      @JsonProperty("clientSecret") String clientSecret, @JsonProperty("friendlySamlName") String friendlySamlName,
+      @JsonProperty("authenticationEnabled") Boolean authenticationEnabled) {
     super(AuthenticationMechanism.SAML);
     this.identifier = identifier;
     this.displayName = displayName;
@@ -57,6 +59,7 @@ public class SAMLSettings extends NGAuthSettings {
     this.clientId = clientId;
     this.clientSecret = clientSecret;
     this.friendlySamlName = friendlySamlName;
+    this.authenticationEnabled = authenticationEnabled;
   }
 
   @Override

--- a/122-ng-authentication-settings/src/main/java/io/harness/ng/authenticationsettings/impl/AuthenticationSettingsService.java
+++ b/122-ng-authentication-settings/src/main/java/io/harness/ng/authenticationsettings/impl/AuthenticationSettingsService.java
@@ -41,8 +41,16 @@ public interface AuthenticationSettingsService {
   SSOConfig updateSAMLMetadata(@NotNull String accountId, MultipartBody.Part inputStream, String displayName,
       String groupMembershipAttr, @NotNull Boolean authorizationEnabled, String logoutUrl, String entityIdentifier,
       String samlProviderType, String clientId, String clientSecret);
+  // this overloading is for case when updating a SAML setting among list of settings in account {samlSSOId}
+  SSOConfig updateSAMLMetadata(@NotNull String accountId, String samlSSOId, MultipartBody.Part inputStream,
+      String displayName, String groupMembershipAttr, @NotNull Boolean authorizationEnabled, String logoutUrl,
+      String entityIdentifier, String samlProviderType, String clientId, String clientSecret, String friendlySamlName);
   SSOConfig deleteSAMLMetadata(@NotNull String accountIdentifier);
+  // this overloading is for case when we delete a SAML setting among list of settings in account {samlSSOId}
+  SSOConfig deleteSAMLMetadata(@NotNull String accountIdentifier, @NotNull String samlSSOId);
   LoginTypeResponse getSAMLLoginTest(@NotNull String accountIdentifier);
+  // this overloading is for case when we test-connection a SAML setting among list of settings in account {samlSSOId}
+  LoginTypeResponse getSAMLLoginTestV2(@NotNull String accountIdentifier, @NotNull String samlSSOId);
   LDAPSettings getLdapSettings(@NotNull String accountIdentifier);
   LDAPSettings createLdapSettings(@NotNull String accountIdentifier, LDAPSettings ldapSettings);
   LDAPSettings updateLdapSettings(@NotNull String accountIdentifier, LDAPSettings ldapSettings);
@@ -54,4 +62,7 @@ public interface AuthenticationSettingsService {
       @AccountIdentifier String accountIdentifier, SessionTimeoutSettings sessionTimeoutSettings);
 
   PasswordStrengthPolicy getPasswordStrengthSettings(String accountIdentifier);
+  // updates authenticationEnabled value for a SAML setting {samlSSOId} in account
+  void updateAuthenticationForSAMLSetting(
+      @NotNull String accountId, @NotNull String samlSSOId, @NotNull Boolean enable);
 }

--- a/122-ng-authentication-settings/src/main/java/io/harness/ng/authenticationsettings/resources/AuthenticationSettingsResource.java
+++ b/122-ng-authentication-settings/src/main/java/io/harness/ng/authenticationsettings/resources/AuthenticationSettingsResource.java
@@ -49,12 +49,14 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Set;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
@@ -345,18 +347,57 @@ public class AuthenticationSettingsResource {
     accessControlClient.checkForAccessOrThrow(
         ResourceScope.of(accountId, null, null), Resource.of(AUTHSETTING, null), EDIT_AUTHSETTING_PERMISSION);
     try {
-      MultipartBody.Part formData = null;
-      if (uploadedInputStream != null) {
-        byte[] bytes = IOUtils.toByteArray(new BoundedInputStream(
-            uploadedInputStream, mainConfiguration.getFileUploadLimits().getCommandUploadLimit()));
-        formData = MultipartBody.Part.createFormData("file", null, RequestBody.create(MultipartBody.FORM, bytes));
-      }
+      MultipartBody.Part formData = getMultipartBodyFromInputStream(uploadedInputStream);
       SSOConfig response =
           authenticationSettingsService.updateSAMLMetadata(accountId, formData, displayName, groupMembershipAttr,
               authorizationEnabled, logoutUrl, entityIdentifier, samlProviderType, clientId, clientSecret);
       return new RestResponse<>(response);
     } catch (Exception e) {
       throw new GeneralException("Error while editing saml-config", e);
+    }
+  }
+
+  @Multipart
+  @PUT
+  @Path("/saml-metadata-upload/{samlSSOId}")
+  @Consumes("multipart/form-data")
+  @ApiOperation(value = "Edit SAML Config for a given SAML SSO Id", nickname = "updateSamlMetaDataForSamlSSOId")
+  @Operation(operationId = "updateSamlMetaDataForSamlSSOId", summary = "Update SAML metadata for a given SAML SSO Id",
+      description = "Updates SAML metadata of the SAML configuration with given SSO Id, configured for an account",
+      responses =
+      {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "default",
+            description = "Successfully updated SAML metadata of SAML setting configured for an account")
+      })
+  public RestResponse<SSOConfig>
+  updateSamlMetaDataForSamlSSOId(@Parameter(description = ACCOUNT_PARAM_MESSAGE) @QueryParam(
+                                     NGCommonEntityConstants.ACCOUNT_KEY) @NotNull String accountId,
+      @Parameter(description = "Saml Settings Identifier") @PathParam("samlSSOId") String samlSSOId,
+      @Parameter(description = "SAML Metadata input file") @FormDataParam("file") InputStream uploadedInputStream,
+      @Parameter(description = "Input file metadata") @FormDataParam(
+          "fileMetadata") FormDataContentDisposition fileDetail,
+      @Parameter(description = "Display Name of the SAML") @FormDataParam("displayName") String displayName,
+      @Parameter(description = "Group membership attribute") @FormDataParam(
+          "groupMembershipAttr") String groupMembershipAttr,
+      @Parameter(description = "Specify whether or not to enable authorization") @FormDataParam("authorizationEnabled")
+      Boolean authorizationEnabled, @Parameter(description = "Logout URL") @FormDataParam("logoutUrl") String logoutUrl,
+      @Parameter(description = "SAML metadata Identifier") @FormDataParam("entityIdentifier") String entityIdentifier,
+      @Parameter(description = "SAML provider type") @FormDataParam("samlProviderType") String samlProviderType,
+      @Parameter(description = "Optional SAML clientId for Azure SSO") @FormDataParam("clientId") String clientId,
+      @Parameter(description = "Optional SAML clientSecret reference string for Azure SSO") @FormDataParam(
+          "clientSecret") String clientSecret,
+      @Parameter(description = "Friendly name of the app on SAML SSO provider end in Harness") @FormDataParam(
+          "friendlySamlName") String friendlySamlName) {
+    accessControlClient.checkForAccessOrThrow(
+        ResourceScope.of(accountId, null, null), Resource.of(AUTHSETTING, null), EDIT_AUTHSETTING_PERMISSION);
+    try {
+      MultipartBody.Part formData = getMultipartBodyFromInputStream(uploadedInputStream);
+      SSOConfig response = authenticationSettingsService.updateSAMLMetadata(accountId, samlSSOId, formData, displayName,
+          groupMembershipAttr, authorizationEnabled, logoutUrl, entityIdentifier, samlProviderType, clientId,
+          clientSecret, friendlySamlName);
+      return new RestResponse<>(response);
+    } catch (Exception e) {
+      throw new GeneralException("Error while editing saml-config " + samlSSOId, e);
     }
   }
 
@@ -379,6 +420,49 @@ public class AuthenticationSettingsResource {
     return new RestResponse<>(response);
   }
 
+  @DELETE
+  @Path("/saml-metadata/{samlSSOId}/delete")
+  @ApiOperation(value = "Delete SAML Config for given SAML sso id", nickname = "deleteSamlMetaDataForSamlSSOId")
+  @Operation(operationId = "deleteSamlMetaDataForSamlSSOId", summary = "Delete SAML meta data for given SAML sso id",
+      description = "Deletes SAML metadata for the given Account and SAML sso id",
+      responses =
+      {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "default",
+            description = "Successfully deleted SAML meta associated with a SAML SSO setting id")
+      })
+  public RestResponse<SSOConfig>
+  deleteSamlMetadataForSamlSSOId(@Parameter(description = ACCOUNT_PARAM_MESSAGE) @QueryParam(
+                                     NGCommonEntityConstants.ACCOUNT_KEY) @NotNull String accountIdentifier,
+      @Parameter(description = "Saml Settings Identifier") @PathParam("samlSSOId") String samlSSOId) {
+    accessControlClient.checkForAccessOrThrow(
+        ResourceScope.of(accountIdentifier, null, null), Resource.of(AUTHSETTING, null), DELETE_AUTHSETTING_PERMISSION);
+    SSOConfig response = authenticationSettingsService.deleteSAMLMetadata(accountIdentifier, samlSSOId);
+    return new RestResponse<>(response);
+  }
+
+  @PUT
+  @Path("/saml-metadata-upload/{samlSSOId}/authentication")
+  @ApiOperation(value = "Enables or disables authentication for the given SAML sso id",
+      nickname = "enableDisableAuthenticationForSAMLSetting")
+  @Operation(operationId = "enableDisableAuthenticationForSAMLSetting",
+      summary = "Update authentication enabled or not for given SAML setting",
+      description = "Updates if authentication is enabled or not for given SAML setting in Account ID.",
+      responses =
+      {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "default",
+            description = "Successfully updated login allowed status for SAML setting in account")
+      })
+  public RestResponse<Boolean>
+  enableDisableLoginForSAMLSetting(@Parameter(description = ACCOUNT_PARAM_MESSAGE) @QueryParam(
+                                       NGCommonEntityConstants.ACCOUNT_KEY) @NotNull String accountIdentifier,
+      @NotNull @QueryParam("enable") @DefaultValue("true") Boolean enable,
+      @Parameter(description = "Saml Settings Identifier") @PathParam("samlSSOId") String samlSSOId) {
+    accessControlClient.checkForAccessOrThrow(
+        ResourceScope.of(accountIdentifier, null, null), Resource.of(AUTHSETTING, null), EDIT_AUTHSETTING_PERMISSION);
+    authenticationSettingsService.updateAuthenticationForSAMLSetting(accountIdentifier, samlSSOId, enable);
+    return new RestResponse<>(true);
+  }
+
   @GET
   @Path("/saml-login-test")
   @ApiOperation(value = "Get SAML Login Test", nickname = "getSamlLoginTest")
@@ -394,6 +478,26 @@ public class AuthenticationSettingsResource {
     accessControlClient.checkForAccessOrThrow(
         ResourceScope.of(accountId, null, null), Resource.of(AUTHSETTING, null), VIEW_AUTHSETTING_PERMISSION);
     LoginTypeResponse response = authenticationSettingsService.getSAMLLoginTest(accountId);
+    return new RestResponse<>(response);
+  }
+
+  @GET
+  @Path("/saml-login-test/{samlSSOId}")
+  @ApiOperation(value = "Get SAML Login Test", nickname = "getSamlLoginTestV2")
+  @Operation(operationId = "getSamlLoginTestV2", summary = "Test SAML connectivity",
+      description = "Tests SAML connectivity for the given Account ID and SAML setting.",
+      responses =
+      {
+        @io.swagger.v3.oas.annotations.responses.
+        ApiResponse(responseCode = "default", description = "Returns connectivity status")
+      })
+  public RestResponse<LoginTypeResponse>
+  getSamlLoginTestV2(@Parameter(description = ACCOUNT_PARAM_MESSAGE) @QueryParam(
+                         NGCommonEntityConstants.ACCOUNT_KEY) @NotNull String accountId,
+      @Parameter(description = "Saml Settings Identifier") @PathParam("samlSSOId") String samlSSOId) {
+    accessControlClient.checkForAccessOrThrow(
+        ResourceScope.of(accountId, null, null), Resource.of(AUTHSETTING, null), VIEW_AUTHSETTING_PERMISSION);
+    LoginTypeResponse response = authenticationSettingsService.getSAMLLoginTestV2(accountId, samlSSOId);
     return new RestResponse<>(response);
   }
 
@@ -523,5 +627,13 @@ public class AuthenticationSettingsResource {
     boolean response =
         authenticationSettingsService.setSessionTimeoutAtAccountLevel(accountIdentifier, sessionTimeoutSettings);
     return new RestResponse<>(response);
+  }
+
+  private MultipartBody.Part getMultipartBodyFromInputStream(InputStream uploadedInputStream) throws IOException {
+    return uploadedInputStream == null ? null
+                                       : MultipartBody.Part.createFormData("file", null,
+                                           RequestBody.create(MultipartBody.FORM,
+                                               IOUtils.toByteArray(new BoundedInputStream(uploadedInputStream,
+                                                   mainConfiguration.getFileUploadLimits().getCommandUploadLimit()))));
   }
 }

--- a/123-ng-core-user/src/main/java/io/harness/ng/authenticationsettings/remote/AuthSettingsManagerClient.java
+++ b/123-ng-core-user/src/main/java/io/harness/ng/authenticationsettings/remote/AuthSettingsManagerClient.java
@@ -105,14 +105,40 @@ public interface AuthSettingsManagerClient {
       @Part("entityIdentifier") RequestBody entityIdentifier, @Part("samlProviderType") RequestBody samlProviderType,
       @Part("clientId") RequestBody clientId, @Part("clientSecret") RequestBody clientSecret);
 
+  @Multipart
+  @PUT(API_PREFIX + "sso/saml-idp-metadata-upload-sso-id")
+  Call<RestResponse<SSOConfig>> updateSAMLMetadata(@Query("accountId") String accountId,
+      @Query("samlSSOId") String samlSSOId, @Part MultipartBody.Part uploadedInputStream,
+      @Part("displayName") RequestBody displayName, @Part("groupMembershipAttr") RequestBody groupMembershipAttr,
+      @Part("authorizationEnabled") RequestBody authorizationEnabled, @Part("logoutUrl") RequestBody logoutUrl,
+      @Part("entityIdentifier") RequestBody entityIdentifier, @Part("samlProviderType") RequestBody samlProviderType,
+      @Part("clientId") RequestBody clientId, @Part("clientSecret") RequestBody clientSecret,
+      @Part("friendlySamlName") RequestBody friendlySamlAppName);
+
   @DELETE(API_PREFIX + "sso/delete-saml-idp-metadata")
   Call<RestResponse<SSOConfig>> deleteSAMLMetadata(@Query("accountId") String accountIdentifier);
+
+  @DELETE(API_PREFIX + "sso/delete-saml-idp-metadata-sso-id")
+  Call<RestResponse<SSOConfig>> deleteSAMLMetadata(
+      @Query("accountId") String accountIdentifier, @Query("samlSSOId") String samlSSOId);
 
   @GET(API_PREFIX + "sso/get-saml-settings")
   Call<RestResponse<SamlSettings>> getSAMLMetadata(@Query("accountId") String accountIdentifier);
 
+  @GET(API_PREFIX + "sso/get-saml-settings-sso-id")
+  Call<RestResponse<SamlSettings>> getSAMLMetadata(
+      @Query("accountId") String accountIdentifier, @Query("samlSSOId") String samlSSOId);
+
+  @PUT(API_PREFIX + "sso/update-saml-setting-authentication")
+  Call<RestResponse<Boolean>> updateAuthenticationEnabledForSAMLSetting(@Query("accountId") @NotEmpty String accountId,
+      @Query("samlSSOId") @NotEmpty String samlSSOId, @Query("enable") boolean enable);
+
   @GET(API_PREFIX + "sso/saml-login-test")
   Call<RestResponse<LoginTypeResponse>> getSAMLLoginTest(@Query("accountId") @NotEmpty String accountIdentifier);
+
+  @GET(API_PREFIX + "sso/v2/saml-login-test")
+  Call<RestResponse<LoginTypeResponse>> getSAMLLoginTestV2(
+      @Query("accountId") @NotEmpty String accountIdentifier, @Query("samlSSOId") @NotEmpty String samlSSOId);
 
   @PUT(API_PREFIX + "user/two-factor-admin-override-settings")
   Call<RestResponse<Boolean>> setTwoFactorAuthAtAccountLevel(@Query("accountId") @NotEmpty String accountId,

--- a/123-ng-core-user/src/main/java/io/harness/ng/core/api/impl/UserGroupServiceImpl.java
+++ b/123-ng-core-user/src/main/java/io/harness/ng/core/api/impl/UserGroupServiceImpl.java
@@ -12,6 +12,7 @@ import static io.harness.NGConstants.DEFAULT_ORGANIZATION_LEVEL_USER_GROUP_IDENT
 import static io.harness.NGConstants.DEFAULT_PROJECT_LEVEL_USER_GROUP_IDENTIFIER;
 import static io.harness.accesscontrol.principals.PrincipalType.USER_GROUP;
 import static io.harness.annotations.dev.HarnessTeam.PL;
+import static io.harness.beans.FeatureName.PL_ENABLE_MULTIPLE_IDP_SUPPORT;
 import static io.harness.data.structure.EmptyPredicate.isEmpty;
 import static io.harness.data.structure.EmptyPredicate.isNotEmpty;
 import static io.harness.exception.WingsException.GROUP;
@@ -845,7 +846,9 @@ public class UserGroupServiceImpl implements UserGroupService {
       throw new InvalidRequestException("SSO Provider already linked to the group. Try unlinking first.");
     }
 
-    SSOConfig ssoConfig = getResponse(managerClient.getAccountAccessManagementSettings(accountIdentifier));
+    SSOConfig ssoConfig = ngFeatureFlagHelperService.isEnabled(accountIdentifier, PL_ENABLE_MULTIPLE_IDP_SUPPORT)
+        ? getResponse(managerClient.getAccountAccessManagementSettingsV2(accountIdentifier))
+        : getResponse(managerClient.getAccountAccessManagementSettings(accountIdentifier));
 
     List<SSOSettings> ssoSettingsList = ssoConfig.getSsoSettings();
     SSOSettings ssoSettings = null;

--- a/400-rest/src/main/java/software/wings/beans/sso/SamlSettings.java
+++ b/400-rest/src/main/java/software/wings/beans/sso/SamlSettings.java
@@ -8,7 +8,6 @@
 package software.wings.beans.sso;
 
 import static io.harness.annotations.dev.HarnessTeam.PL;
-import static io.harness.data.structure.EmptyPredicate.isEmpty;
 import static io.harness.data.structure.EmptyPredicate.isNotEmpty;
 
 import static software.wings.settings.SettingVariableTypes.SSO_SAML;
@@ -51,6 +50,8 @@ public class SamlSettings extends SSOSettings implements EncryptableSetting {
   @Encrypted(fieldName = "clientSecret") private char[] clientSecret;
   @SchemaIgnore private String encryptedClientSecret;
   private String friendlySamlName;
+  private boolean configuredFromNG;
+  private boolean authenticationEnabled;
 
   @JsonCreator
   @Builder
@@ -72,7 +73,7 @@ public class SamlSettings extends SSOSettings implements EncryptableSetting {
     this.samlProviderType = samlProviderType;
     this.clientId = clientId;
     this.clientSecret = clientSecret == null ? null : clientSecret.clone();
-    this.friendlySamlName = isEmpty(friendlySamlName) ? displayName : friendlySamlName;
+    this.friendlySamlName = friendlySamlName;
   }
 
   @Override

--- a/400-rest/src/main/java/software/wings/features/LdapFeature.java
+++ b/400-rest/src/main/java/software/wings/features/LdapFeature.java
@@ -57,7 +57,7 @@ public class LdapFeature extends AbstractPremiumFeature implements ComplianceByR
 
     if (!accountService.get(accountId).isOauthEnabled() && targetAccountType.equals(AccountType.COMMUNITY)) {
       ssoService.uploadOauthConfiguration(accountId, "", EnumSet.allOf(OauthProviderType.class));
-      ssoService.setAuthenticationMechanism(accountId, AuthenticationMechanism.OAUTH);
+      ssoService.setAuthenticationMechanism(accountId, AuthenticationMechanism.OAUTH, false);
     }
 
     return isUsageCompliantWithRestrictions(accountId, targetAccountType);

--- a/400-rest/src/main/java/software/wings/features/SamlFeature.java
+++ b/400-rest/src/main/java/software/wings/features/SamlFeature.java
@@ -56,7 +56,7 @@ public class SamlFeature extends AbstractPremiumFeature implements ComplianceByR
 
     if (!accountService.get(accountId).isOauthEnabled() && targetAccountType.equals(AccountType.COMMUNITY)) {
       ssoService.uploadOauthConfiguration(accountId, "", EnumSet.allOf(OauthProviderType.class));
-      ssoService.setAuthenticationMechanism(accountId, AuthenticationMechanism.OAUTH);
+      ssoService.setAuthenticationMechanism(accountId, AuthenticationMechanism.OAUTH, false);
     }
 
     return isUsageCompliantWithRestrictions(accountId, targetAccountType);

--- a/400-rest/src/main/java/software/wings/resources/SSOResource.java
+++ b/400-rest/src/main/java/software/wings/resources/SSOResource.java
@@ -148,7 +148,7 @@ public class SSOResource {
       @FormDataParam("clientSecret") String clientSecret) {
     return new RestResponse<>(ssoService.updateSamlConfiguration(accountId, uploadedInputStream, displayName,
         groupMembershipAttr, authorizationEnabled, logoutUrl, entityIdentifier, samlProviderType, clientId,
-        isEmpty(clientSecret) ? null : clientSecret.toCharArray(), null, false));
+        isEmpty(clientSecret) ? null : clientSecret.toCharArray(), false));
   }
 
   @PUT
@@ -174,7 +174,7 @@ public class SSOResource {
   @ExceptionMetered
   public RestResponse<SSOConfig> setAuthMechanism(@QueryParam("accountId") String accountId,
       @QueryParam("authMechanism") AuthenticationMechanism authenticationMechanism) {
-    return new RestResponse<SSOConfig>(ssoService.setAuthenticationMechanism(accountId, authenticationMechanism));
+    return new RestResponse<>(ssoService.setAuthenticationMechanism(accountId, authenticationMechanism, false));
   }
 
   @PUT
@@ -195,7 +195,7 @@ public class SSOResource {
       throw new InvalidRequestException(response.getMessage());
     }
 
-    return new RestResponse<>(ssoService.setAuthenticationMechanism(accountId, AuthenticationMechanism.LDAP));
+    return new RestResponse<>(ssoService.setAuthenticationMechanism(accountId, AuthenticationMechanism.LDAP, false));
   }
 
   @PUT
@@ -203,7 +203,7 @@ public class SSOResource {
   @Timed
   @ExceptionMetered
   public RestResponse<SSOConfig> enableSamlAuthMechanism(@QueryParam("accountId") String accountId) {
-    return new RestResponse<>(ssoService.setAuthenticationMechanism(accountId, AuthenticationMechanism.SAML));
+    return new RestResponse<>(ssoService.setAuthenticationMechanism(accountId, AuthenticationMechanism.SAML, false));
   }
 
   @PUT
@@ -211,7 +211,7 @@ public class SSOResource {
   @Timed
   @ExceptionMetered
   public RestResponse<SSOConfig> enableOauthAuthMechanism(@QueryParam("accountId") String accountId) {
-    return new RestResponse<>(ssoService.setAuthenticationMechanism(accountId, AuthenticationMechanism.OAUTH));
+    return new RestResponse<>(ssoService.setAuthenticationMechanism(accountId, AuthenticationMechanism.OAUTH, false));
   }
 
   @PUT
@@ -219,7 +219,8 @@ public class SSOResource {
   @Timed
   @ExceptionMetered
   public RestResponse<SSOConfig> enableBasicAuthMechanism(@QueryParam("accountId") String accountId) {
-    return new RestResponse<>(ssoService.setAuthenticationMechanism(accountId, AuthenticationMechanism.USER_PASSWORD));
+    return new RestResponse<>(
+        ssoService.setAuthenticationMechanism(accountId, AuthenticationMechanism.USER_PASSWORD, false));
   }
 
   @GET

--- a/400-rest/src/main/java/software/wings/resources/SSOResourceNG.java
+++ b/400-rest/src/main/java/software/wings/resources/SSOResourceNG.java
@@ -55,6 +55,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
@@ -99,7 +100,6 @@ public class SSOResourceNG {
   @GET
   @Path("v2/get-access-management")
   @Timed
-  @AuthRule(permissionType = LOGGED_IN)
   @ExceptionMetered
   @InternalApi
   public RestResponse<SSOConfig> getAccountAccessManagementSettingsV2(@QueryParam("accountId") String accountId) {
@@ -122,7 +122,7 @@ public class SSOResourceNG {
   @ExceptionMetered
   public RestResponse<SSOConfig> setAuthMechanism(@QueryParam("accountId") String accountId,
       @QueryParam("authMechanism") AuthenticationMechanism authenticationMechanism) {
-    return new RestResponse<>(ssoService.setAuthenticationMechanism(accountId, authenticationMechanism));
+    return new RestResponse<>(ssoService.setAuthenticationMechanism(accountId, authenticationMechanism, true));
   }
 
   @DELETE
@@ -138,6 +138,16 @@ public class SSOResourceNG {
   @Timed
   @ExceptionMetered
   public RestResponse<SamlSettings> getSamlSetting(@QueryParam("accountId") String accountId) {
+    return new RestResponse<>(ssoService.getSamlSettings(accountId));
+  }
+
+  @GET
+  @Path("get-saml-settings-sso-id")
+  @Timed
+  @ExceptionMetered
+  @InternalApi
+  public RestResponse<SamlSettings> getSamlSetting(
+      @QueryParam("accountId") String accountId, @QueryParam("samlSSOId") String samlSSOId) {
     return new RestResponse<>(ssoService.getSamlSettings(accountId));
   }
 
@@ -174,7 +184,38 @@ public class SSOResourceNG {
     final String clientSecretRef = getCGSecretManagerRefForClientSecret(accountId, false, clientId, clientSecret);
     return new RestResponse<>(ssoService.updateSamlConfiguration(accountId, uploadedInputStream, displayName,
         groupMembershipAttr, authorizationEnabled, logoutUrl, entityIdentifier, samlProviderType, clientId,
-        isEmpty(clientSecretRef) ? null : clientSecretRef.toCharArray(), null, true));
+        isEmpty(clientSecretRef) ? null : clientSecretRef.toCharArray(), true));
+  }
+
+  @PUT
+  @Path("saml-idp-metadata-upload-sso-id")
+  @Timed
+  @ExceptionMetered
+  @InternalApi
+  public RestResponse<SSOConfig> updateSamlMetaData(@QueryParam("accountId") String accountId,
+      @QueryParam("samlSSOId") String samlSSOId, @FormDataParam("file") InputStream uploadedInputStream,
+      @FormDataParam("displayName") String displayName,
+      @FormDataParam("groupMembershipAttr") String groupMembershipAttr,
+      @FormDataParam("authorizationEnabled") Boolean authorizationEnabled, @FormDataParam("logoutUrl") String logoutUrl,
+      @FormDataParam("entityIdentifier") String entityIdentifier,
+      @FormDataParam("samlProviderType") String samlProviderType, @FormDataParam("clientId") String clientId,
+      @FormDataParam("clientSecret") String clientSecret,
+      @FormDataParam("friendlySamlName") String friendlySamlAppName) {
+    final String clientSecretRef = getCGSecretManagerRefForClientSecret(accountId, false, clientId, clientSecret);
+    return new RestResponse<>(ssoService.updateSamlConfiguration(accountId, samlSSOId, uploadedInputStream, displayName,
+        groupMembershipAttr, authorizationEnabled, logoutUrl, entityIdentifier, samlProviderType, clientId,
+        isEmpty(clientSecretRef) ? null : clientSecretRef.toCharArray(), friendlySamlAppName, true));
+  }
+
+  @PUT
+  @Path("update-saml-setting-authentication")
+  @Timed
+  @ExceptionMetered
+  @InternalApi
+  public RestResponse<Boolean> updateLoginEnabledForSAMLSetting(@QueryParam("accountId") String accountId,
+      @QueryParam("samlSSOId") String samlSSOId, @QueryParam("enable") @DefaultValue("true") boolean enable) {
+    ssoService.updateAuthenticationEnabledForSAMLSetting(accountId, samlSSOId, enable);
+    return new RestResponse<>(true);
   }
 
   @DELETE
@@ -186,12 +227,35 @@ public class SSOResourceNG {
     return new RestResponse<SSOConfig>(ssoService.deleteSamlConfiguration(accountId));
   }
 
+  @DELETE
+  @Path("delete-saml-idp-metadata-sso-id")
+  @Timed
+  @ExceptionMetered
+  @InternalApi
+  public RestResponse<SSOConfig> deleteSamlMetaData(
+      @QueryParam("accountId") String accountId, @QueryParam("samlSSOId") String samlSSOId) {
+    return new RestResponse<>(ssoService.deleteSamlConfiguration(accountId, samlSSOId));
+  }
+
   @GET
   @Path("saml-login-test")
   public RestResponse<LoginTypeResponse> getSamlLoginTest(@QueryParam("accountId") @NotBlank String accountId) {
     LoginTypeResponseBuilder builder = LoginTypeResponse.builder();
     try {
       builder.SSORequest(samlClientService.generateTestSamlRequest(accountId));
+      return new RestResponse<>(builder.authenticationMechanism(AuthenticationMechanism.SAML).build());
+    } catch (Exception e) {
+      throw new WingsException(ErrorCode.INVALID_SAML_CONFIGURATION);
+    }
+  }
+
+  @GET
+  @Path("v2/saml-login-test")
+  public RestResponse<LoginTypeResponse> getSamlLoginTest(
+      @QueryParam("accountId") @NotBlank String accountId, @QueryParam("samlSSOId") @NotNull String samlSSOId) {
+    LoginTypeResponseBuilder builder = LoginTypeResponse.builder();
+    try {
+      builder.SSORequest(samlClientService.generateTestSamlRequest(accountId, samlSSOId));
       return new RestResponse<>(builder.authenticationMechanism(AuthenticationMechanism.SAML).build());
     } catch (Exception e) {
       throw new WingsException(ErrorCode.INVALID_SAML_CONFIGURATION);

--- a/400-rest/src/main/java/software/wings/service/impl/UserServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/UserServiceImpl.java
@@ -2441,7 +2441,7 @@ public class UserServiceImpl implements UserService {
             .build();
     ssoSettingService.saveOauthSettings(oauthSettings);
     log.info("Setting authentication mechanism as oauth for account id: {}", accountId);
-    ssoService.setAuthenticationMechanism(accountId, AuthenticationMechanism.OAUTH);
+    ssoService.setAuthenticationMechanism(accountId, AuthenticationMechanism.OAUTH, false);
   }
 
   @Override

--- a/400-rest/src/main/java/software/wings/service/intfc/SSOService.java
+++ b/400-rest/src/main/java/software/wings/service/intfc/SSOService.java
@@ -43,16 +43,28 @@ public interface SSOService {
 
   SSOConfig updateSamlConfiguration(@NotNull String accountId, InputStream inputStream, String displayName,
       String groupMembershipAttr, @NotNull Boolean authorizationEnabled, String logoutUrl, String entityIdentifier,
-      String samlProviderType, String clientId, char[] clientSecret, String friendlySamlName, boolean isNGSSO);
+      String samlProviderType, String clientId, char[] clientSecret, boolean isNGSSO);
+
+  // this overloading is for updating a SAML setting (samlSSOId) among list of saml settings in account
+  SSOConfig updateSamlConfiguration(@NotNull String accountId, @NotNull String samlSSOId, InputStream inputStream,
+      String displayName, String groupMembershipAttr, @NotNull Boolean authorizationEnabled, String logoutUrl,
+      String entityIdentifier, String samlProviderType, String clientId, char[] clientSecret,
+      String friendlySamlAppName, boolean isNGSSO);
 
   SSOConfig updateLogoutUrlSamlSettings(@NotNull String accountId, @NotNull String logoutUrl);
 
   SSOConfig deleteSamlConfiguration(@NotNull String accountId);
 
+  // this overloading is for deleting a SAML setting (samlSSOId) among list of saml settings in account
+  SSOConfig deleteSamlConfiguration(@NotNull String accountId, @NotNull String samlSSOId);
+
   SSOConfig setAuthenticationMechanism(
-      @NotNull String accountId, @NotNull AuthenticationMechanism authenticationMechanism);
+      @NotNull String accountId, @NotNull AuthenticationMechanism authenticationMechanism, boolean isFromNG);
 
   SSOConfig getAccountAccessManagementSettings(@NotNull String accountId);
+
+  // this overloading is for NG case
+  // SSOConfig getAccountAccessManagementSettings(@NotNull String accountId, boolean isNGSSO);
 
   SSOConfig getAccountAccessManagementSettingsV2(@NotNull String accountId);
 
@@ -68,6 +80,9 @@ public interface SSOService {
   LdapSettings deleteLdapSettings(@NotBlank String accountId);
 
   SamlSettings getSamlSettings(@NotBlank String accountId);
+
+  // this overloading is to GET a SAML setting (samlSSOId) among list of saml settings in account
+  SamlSettings getSamlSettings(@NotBlank String accountId, @NotNull String samlSSOId);
 
   LdapTestResponse validateLdapConnectionSettings(@NotNull LdapSettings ldapSettings, @NotBlank String accountId);
 
@@ -88,4 +103,6 @@ public interface SSOService {
 
   LdapSettingsWithEncryptedDataAndPasswordDetail getLdapSettingsWithEncryptedDataAndPasswordDetail(
       @NotBlank String accountId, @NotBlank String password);
+
+  void updateAuthenticationEnabledForSAMLSetting(@NotBlank String accountId, @NotNull String samlSSOId, boolean enable);
 }

--- a/400-rest/src/main/java/software/wings/service/intfc/SSOSettingService.java
+++ b/400-rest/src/main/java/software/wings/service/intfc/SSOSettingService.java
@@ -39,19 +39,34 @@ public interface SSOSettingService extends OwnedByAccount {
 
   SamlSettings getSamlSettingsByAccountId(@NotNull String accountId);
 
+  SamlSettings getSamlSettingsByAccountIdNotConfiguredFromNG(@NotNull String accountId);
+
   OauthSettings getOauthSettingsByAccountId(String accountId);
 
   @ValidationGroups(Create.class) SamlSettings saveSamlSettings(@Valid SamlSettings settings);
 
+  // this overloading is for multiple-saml case with FF handling
+  @ValidationGroups(Create.class)
+  SamlSettings saveSamlSettings(@Valid SamlSettings settings, boolean isUpdateCase, boolean isNGSso);
+
   // This function is meant to be called for ng sso settings, as the license check is already done in NG Service
   SamlSettings saveSamlSettingsWithoutCGLicenseCheck(
       @GetAccountId(SamlSettingsAccountIdExtractor.class) SamlSettings settings);
+
+  // This overloaded function is meant to be called for ng sso settings, without CG license check & overloading is for
+  // multiple-saml case with FF handling
+  SamlSettings saveSamlSettingsWithoutCGLicenseCheck(
+      @GetAccountId(SamlSettingsAccountIdExtractor.class) SamlSettings settings, boolean isUpdateCase, boolean isNGSso);
+
+  void updateAuthenticationEnabledForSAMLSetting(@NotNull String accountId, @NotNull String samlSSOId, boolean enable);
 
   OauthSettings saveOauthSettings(OauthSettings settings);
 
   boolean deleteSamlSettings(@NotNull String accountId);
 
   boolean deleteSamlSettings(SamlSettings samlSettings);
+
+  boolean deleteSamlSettingsWithAudits(SamlSettings samlSettings);
 
   SamlSettings getSamlSettingsByOrigin(@NotNull String origin);
 
@@ -74,6 +89,8 @@ public interface SSOSettingService extends OwnedByAccount {
   SSOSettings getSsoSettings(@NotBlank String uuid);
 
   List<SamlSettings> getSamlSettingsListByAccountId(@NotNull String accountId);
+
+  SamlSettings getSamlSettingsByAccountIdAndUuid(@NotNull String accountId, String uuid);
 
   /**
    * Raise group sync alert specifying the cause of the failure

--- a/400-rest/src/test/java/software/wings/security/saml/SamlClientServiceTest.java
+++ b/400-rest/src/test/java/software/wings/security/saml/SamlClientServiceTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package software.wings.security.saml;
+
+import static io.harness.annotations.dev.HarnessTeam.PL;
+import static io.harness.rule.OwnerRule.PRATEEK;
+
+import static software.wings.beans.Account.Builder.anAccount;
+
+import static junit.framework.TestCase.assertNotNull;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import io.harness.CategoryTest;
+import io.harness.annotations.dev.HarnessModule;
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.annotations.dev.TargetModule;
+import io.harness.category.element.UnitTests;
+import io.harness.rule.Owner;
+
+import software.wings.beans.Account;
+import software.wings.beans.sso.SamlSettings;
+import software.wings.service.impl.AccountServiceImpl;
+import software.wings.service.intfc.SSOSettingService;
+import software.wings.utils.WingsTestConstants;
+
+import com.coveo.saml.SamlClient;
+import com.coveo.saml.SamlException;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.apache.commons.io.IOUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+
+@OwnedBy(PL)
+@TargetModule(HarnessModule._950_NG_AUTHENTICATION_SERVICE)
+public class SamlClientServiceTest extends CategoryTest {
+  @Mock private AccountServiceImpl accountService;
+  @Mock SSOSettingService ssoSettingService;
+
+  @InjectMocks @Spy private SamlClientService samlClientService;
+
+  @Before
+  public void setUp() throws IOException {
+    initMocks(this);
+  }
+
+  @Test
+  @Owner(developers = PRATEEK)
+  @Category(UnitTests.class)
+  public void testGetSamlClientFromAccountAndSamlId() throws IOException, SamlException {
+    String uuidString = UUID.randomUUID().toString();
+
+    Account testAccount = anAccount()
+                              .withUuid("testAccountId")
+                              .withAccountName(WingsTestConstants.ACCOUNT_NAME)
+                              .withCompanyName(WingsTestConstants.COMPANY_NAME)
+                              .build();
+
+    when(ssoSettingService.getSamlSettingsListByAccountId("testAccountId")).thenReturn(getSamlSettingsList(uuidString));
+    SamlClient samlClient = samlClientService.getSamlClientFromAccountAndSamlId(testAccount, uuidString);
+    assertNotNull(samlClient);
+    assertNotNull(samlClient.getSamlRequest());
+  }
+
+  @Test
+  @Owner(developers = PRATEEK)
+  @Category(UnitTests.class)
+  public void testGenerateTestSamlRequest() throws IOException {
+    final String uuidStr = UUID.randomUUID().toString();
+    String testAccountId = "testAccountId";
+
+    Account testAccount = anAccount()
+                              .withUuid(testAccountId)
+                              .withAccountName(WingsTestConstants.ACCOUNT_NAME)
+                              .withCompanyName(WingsTestConstants.COMPANY_NAME)
+                              .build();
+
+    when(ssoSettingService.getSamlSettingsListByAccountId(testAccountId)).thenReturn(getSamlSettingsList(uuidStr));
+    when(accountService.get(testAccountId)).thenReturn(testAccount);
+    SSORequest ssoRequestResult = samlClientService.generateTestSamlRequest(testAccountId, uuidStr);
+    assertNotNull(ssoRequestResult);
+    assertNotNull(ssoRequestResult.getIdpRedirectUrl());
+  }
+
+  private List<SamlSettings> getSamlSettingsList(String uuidString) throws IOException {
+    String xml = IOUtils.toString(getClass().getResourceAsStream("/Azure-1-metadata.xml"), Charset.defaultCharset());
+
+    SamlSettings azureSetting1 =
+        SamlSettings.builder()
+            .metaDataFile(xml)
+            .url("https://login.microsoftonline.com/b229b2bb-5f33-4d22-bce0-730f6474e906/saml2")
+            .accountId("TestAzureAccount1")
+            .displayName("Azure001")
+            .origin("login.microsoftonline.com")
+            .build();
+    azureSetting1.setUuid(uuidString);
+    List<SamlSettings> samlSettingsList = new ArrayList<>();
+    samlSettingsList.add(azureSetting1);
+    return samlSettingsList;
+  }
+}

--- a/400-rest/src/test/java/software/wings/service/impl/SSOServiceImplTest.java
+++ b/400-rest/src/test/java/software/wings/service/impl/SSOServiceImplTest.java
@@ -8,6 +8,7 @@
 package software.wings.service.impl;
 
 import static io.harness.annotations.dev.HarnessModule._950_NG_AUTHENTICATION_SERVICE;
+import static io.harness.beans.FeatureName.PL_ENABLE_MULTIPLE_IDP_SUPPORT;
 import static io.harness.ng.core.account.AuthenticationMechanism.LDAP;
 import static io.harness.ng.core.account.AuthenticationMechanism.OAUTH;
 import static io.harness.ng.core.account.AuthenticationMechanism.SAML;
@@ -131,25 +132,25 @@ public class SSOServiceImplTest extends WingsBaseTest {
 
     // UP -> UP + OA - enable oauth
     ssoService.uploadOauthConfiguration(account.getUuid(), "", Sets.newHashSet(OauthProviderType.values()));
-    ssoService.setAuthenticationMechanism(account.getUuid(), OAUTH);
+    ssoService.setAuthenticationMechanism(account.getUuid(), OAUTH, false);
     account = accountService.get(account.getUuid());
     assertThat(account.getAuthenticationMechanism()).isEqualTo(USER_PASSWORD);
     assertThat(account.isOauthEnabled()).isTrue();
 
     // UP + OA -> OA - disable user password
-    ssoService.setAuthenticationMechanism(account.getUuid(), OAUTH);
+    ssoService.setAuthenticationMechanism(account.getUuid(), OAUTH, false);
     account = accountService.get(account.getUuid());
     assertThat(account.getAuthenticationMechanism()).isEqualTo(OAUTH);
     assertThat(account.isOauthEnabled()).isTrue();
 
     // OA -> UP + OA - enable user password
-    ssoService.setAuthenticationMechanism(account.getUuid(), USER_PASSWORD);
+    ssoService.setAuthenticationMechanism(account.getUuid(), USER_PASSWORD, false);
     account = accountService.get(account.getUuid());
     assertThat(account.getAuthenticationMechanism()).isEqualTo(USER_PASSWORD);
     assertThat(account.isOauthEnabled()).isTrue();
 
     // UP + OA -> UP - disable oauth
-    ssoService.setAuthenticationMechanism(account.getUuid(), USER_PASSWORD);
+    ssoService.setAuthenticationMechanism(account.getUuid(), USER_PASSWORD, false);
     account = accountService.get(account.getUuid());
     assertThat(account.getAuthenticationMechanism()).isEqualTo(USER_PASSWORD);
     assertThat(account.isOauthEnabled()).isFalse();
@@ -185,7 +186,7 @@ public class SSOServiceImplTest extends WingsBaseTest {
     // Upload SAML config and enable
     ssoService.uploadSamlConfiguration(accountId, new ByteArrayInputStream("test data".getBytes()), "test", "", false,
         "", "", SAMLProviderType.ONELOGIN.name(), anyString(), any(), "testOtherSamlName", false);
-    ssoService.setAuthenticationMechanism(accountId, SAML);
+    ssoService.setAuthenticationMechanism(accountId, SAML, false);
     account = accountService.get(account.getUuid());
     assertThat(account.getAuthenticationMechanism()).isEqualTo(SAML);
     assertThat(account.isOauthEnabled()).isFalse();
@@ -222,7 +223,7 @@ public class SSOServiceImplTest extends WingsBaseTest {
     // Upload SAML config and enable
     ssoService.uploadSamlConfiguration(accountId, new ByteArrayInputStream("test data".getBytes()), "test", "", false,
         "", "", SAMLProviderType.ONELOGIN.name(), anyString(), any(), "testOtherSamlName", false);
-    ssoService.setAuthenticationMechanism(accountId, SAML);
+    ssoService.setAuthenticationMechanism(accountId, SAML, false);
     account = accountService.get(account.getUuid());
     assertThat(account.getAuthenticationMechanism()).isEqualTo(SAML);
     assertThat(account.isOauthEnabled()).isFalse();
@@ -249,7 +250,8 @@ public class SSOServiceImplTest extends WingsBaseTest {
                           .withAuthenticationMechanism(USER_PASSWORD)
                           .build();
     accountService.save(account, false);
-    ssoService.setAuthenticationMechanism(account.getUuid(), SAML);
+    when(featureFlagService.isNotEnabled(PL_ENABLE_MULTIPLE_IDP_SUPPORT, account.getUuid())).thenReturn(true);
+    ssoService.setAuthenticationMechanism(account.getUuid(), SAML, false);
     account = accountService.get(account.getUuid());
     assertThat(account.getAuthenticationMechanism()).isEqualTo(SAML);
     assertThat(account.isOauthEnabled()).isFalse();
@@ -270,7 +272,7 @@ public class SSOServiceImplTest extends WingsBaseTest {
                           .withAuthenticationMechanism(USER_PASSWORD)
                           .build();
     accountService.save(account, false);
-    ssoService.setAuthenticationMechanism(account.getUuid(), LDAP);
+    ssoService.setAuthenticationMechanism(account.getUuid(), LDAP, false);
     account = accountService.get(account.getUuid());
     assertThat(account.getAuthenticationMechanism()).isEqualTo(LDAP);
     assertThat(account.isOauthEnabled()).isFalse();
@@ -327,7 +329,7 @@ public class SSOServiceImplTest extends WingsBaseTest {
     assertThat(account.getAuthenticationMechanism()).isEqualTo(USER_PASSWORD);
     assertThat(account.isOauthEnabled()).isFalse();
 
-    ssoService.setAuthenticationMechanism(account.getUuid(), OAUTH);
+    ssoService.setAuthenticationMechanism(account.getUuid(), OAUTH, false);
     account = accountService.get(account.getUuid());
     assertThat(account.getAuthenticationMechanism()).isEqualTo(USER_PASSWORD);
     assertThat(account.isOauthEnabled()).isTrue();
@@ -448,7 +450,8 @@ public class SSOServiceImplTest extends WingsBaseTest {
                           .build();
     accountService.save(account, false);
 
-    ssoService.setAuthenticationMechanism(account.getUuid(), SAML);
+    when(featureFlagService.isNotEnabled(PL_ENABLE_MULTIPLE_IDP_SUPPORT, account.getUuid())).thenReturn(true);
+    ssoService.setAuthenticationMechanism(account.getUuid(), SAML, false);
     List<OutboxEvent> outboxEvents = outboxService.list(OutboxEventFilter.builder().maximumEventsPolled(10).build());
     OutboxEvent outboxEvent = outboxEvents.get(outboxEvents.size() - 1);
 
@@ -463,7 +466,7 @@ public class SSOServiceImplTest extends WingsBaseTest {
     assertThat(loginSettingsAuthMechanismUpdateEvent.getNewAuthMechanismYamlDTO().getAuthenticationMechanism())
         .isEqualTo(SAML);
 
-    ssoService.setAuthenticationMechanism(account.getUuid(), LDAP);
+    ssoService.setAuthenticationMechanism(account.getUuid(), LDAP, false);
     outboxEvents = outboxService.list(OutboxEventFilter.builder().maximumEventsPolled(10).build());
     outboxEvent = outboxEvents.get(outboxEvents.size() - 1);
 

--- a/956-feature-flag-beans/src/main/java/io/harness/beans/FeatureName.java
+++ b/956-feature-flag-beans/src/main/java/io/harness/beans/FeatureName.java
@@ -635,6 +635,7 @@ public enum FeatureName {
       "Do not add quotes to strings when a user reconciles a template, pipeline", HarnessTeam.CDC, Scope.GLOBAL),
   SSCA_ENABLED("FF to enable SSCA on Harness", HarnessTeam.SSCA),
   PL_NEW_SCIM_STANDARDS("Changes required for being SCIM 2 compliant API calls", HarnessTeam.PL),
+  PL_ENABLE_MULTIPLE_IDP_SUPPORT("Enable support for multiple SSO IDP in an account", HarnessTeam.PL),
   PL_DO_NOT_MIGRATE_NON_ADMIN_CG_USERS_TO_NG("FF to disable CG to NG user migration except Admins", HarnessTeam.PL),
   PIE_EXECUTION_JSON_SUPPORT("Support for storing execution json in mongo", HarnessTeam.PIPELINE),
   PIE_EXPRESSION_ENGINE_V2("Support for new model of expression engine", HarnessTeam.PIPELINE),


### PR DESCRIPTION
* [feat]: [PL-32216]: support for update SAML settings in NG by ssoId. support update, delete, authn enabled on saml ssoid

* [feat]: [PL-32216]: support for update SAML settings in NG by ssoId. support update, delete, authn enabled on saml ssoid

* [feat]: [PL-32216]: add unit tests for various flows

* [feat]: [PL-32216]: fix checkstyle

* [feat]: [PL-32216]: fix checkstyle

* [feat]: [PL-32216]: fix copyright check

* [feat]: [PL-32216]: fix minor bugs and address review comments

* [feat]: [PL-32216]: fix failing unit tests

* [feat]: [PL-32216]: address review comments