### PR TITLE
fix: [SRM-14706]: Delete for SLO is not happening if the project is d… (#47367)

### DIFF
--- a/srm-service/modules/cv-nextgen-service/service/src/main/java/io/harness/cvng/servicelevelobjective/services/api/ServiceLevelObjectiveV2Service.java
+++ b/srm-service/modules/cv-nextgen-service/service/src/main/java/io/harness/cvng/servicelevelobjective/services/api/ServiceLevelObjectiveV2Service.java
@@ -47,6 +47,8 @@ public interface ServiceLevelObjectiveV2Service extends DeleteEntityByHandler<Ab
 
   boolean delete(ProjectParams projectParams, String identifier);
 
+  boolean delete(ProjectParams projectParams, String identifier, boolean validateReferencedCompositeSLOForSimpleSLO);
+
   void setMonitoredServiceSLOsEnableFlag(
       ProjectParams projectParams, String monitoreServiceIdentifier, boolean isEnabled);
 

--- a/srm-service/modules/cv-nextgen-service/service/src/main/java/io/harness/cvng/servicelevelobjective/services/impl/ServiceLevelObjectiveV2ServiceImpl.java
+++ b/srm-service/modules/cv-nextgen-service/service/src/main/java/io/harness/cvng/servicelevelobjective/services/impl/ServiceLevelObjectiveV2ServiceImpl.java
@@ -427,14 +427,21 @@ public class ServiceLevelObjectiveV2ServiceImpl implements ServiceLevelObjective
                       .projectIdentifier(serviceLevelObjective.getProjectIdentifier())
                       .orgIdentifier(serviceLevelObjective.getOrgIdentifier())
                       .build(),
-            serviceLevelObjective.getIdentifier()));
+            serviceLevelObjective.getIdentifier(), false));
   }
   @Override
   public boolean delete(ProjectParams projectParams, String identifier) {
+    return delete(projectParams, identifier, true);
+  }
+
+  @Override
+  public boolean delete(
+      ProjectParams projectParams, String identifier, boolean validateReferencedCompositeSLOForSimpleSLO) {
     AbstractServiceLevelObjective serviceLevelObjectiveV2 = checkIfSLOPresent(projectParams, identifier);
     ServiceLevelObjectiveV2DTO serviceLevelObjectiveDTO =
         sloEntityToSLOResponse(serviceLevelObjectiveV2).getServiceLevelObjectiveV2DTO();
-    if (serviceLevelObjectiveV2.getType().equals(ServiceLevelObjectiveType.SIMPLE)) {
+    if (validateReferencedCompositeSLOForSimpleSLO
+        && serviceLevelObjectiveV2.getType().equals(ServiceLevelObjectiveType.SIMPLE)) {
       List<String> referencedCompositeSLOIdentifiers =
           compositeSLOService.getReferencedCompositeSLOs(projectParams, identifier)
               .stream()
@@ -479,7 +486,6 @@ public class ServiceLevelObjectiveV2ServiceImpl implements ServiceLevelObjective
                            .build());
     return hPersistence.delete(serviceLevelObjectiveV2);
   }
-
   @Override
   public void setMonitoredServiceSLOsEnableFlag(
       ProjectParams projectParams, String monitoredServiceIdentifier, boolean isEnabled) {

--- a/srm-service/modules/cv-nextgen-service/service/src/test/java/io/harness/cvng/servicelevelobjective/services/impl/ServiceLevelObjectiveV2ServiceImplTest.java
+++ b/srm-service/modules/cv-nextgen-service/service/src/test/java/io/harness/cvng/servicelevelobjective/services/impl/ServiceLevelObjectiveV2ServiceImplTest.java
@@ -22,6 +22,7 @@ import static io.harness.rule.OwnerRule.VARSHA_LALWANI;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -2266,7 +2267,7 @@ public class ServiceLevelObjectiveV2ServiceImplTest extends CvNextGenTestBase {
   @Category(UnitTests.class)
   public void testDeleteByProjectIdentifier_Success() {
     ProjectParams projectParamsTest = ProjectParams.builder()
-                                          .accountIdentifier(generateUuid())
+                                          .accountIdentifier(builderFactory.getProjectParams().getAccountIdentifier())
                                           .orgIdentifier("orgIdentifier")
                                           .projectIdentifier("project3")
                                           .build();
@@ -2309,10 +2310,15 @@ public class ServiceLevelObjectiveV2ServiceImplTest extends CvNextGenTestBase {
     compositeSLODTO.setOrgIdentifier(projectParamsTest.getOrgIdentifier());
     compositeSLODTO.setProjectIdentifier(projectParamsTest.getProjectIdentifier());
     mockServiceLevelObjectiveService.create(projectParamsTest, compositeSLODTO);
+
+    compositeSLODTO.setIdentifier("compositeSLO3");
+    compositeSLODTO.setOrgIdentifier(builderFactory.getProjectParams().getOrgIdentifier());
+    compositeSLODTO.setProjectIdentifier(builderFactory.getProjectParams().getOrgIdentifier());
+    mockServiceLevelObjectiveService.create(builderFactory.getProjectParams(), compositeSLODTO);
     mockServiceLevelObjectiveService.deleteByProjectIdentifier(AbstractServiceLevelObjective.class,
         projectParamsTest.getAccountIdentifier(), projectParamsTest.getOrgIdentifier(),
         projectParamsTest.getProjectIdentifier());
-    verify(mockServiceLevelObjectiveService, times(3)).delete(any(), any());
+    verify(mockServiceLevelObjectiveService, times(3)).delete(any(), any(), anyBoolean());
   }
 
   @Test
@@ -2365,7 +2371,7 @@ public class ServiceLevelObjectiveV2ServiceImplTest extends CvNextGenTestBase {
     mockServiceLevelObjectiveService.create(projectParamsTest, compositeSLODTO);
     mockServiceLevelObjectiveService.deleteByOrgIdentifier(AbstractServiceLevelObjective.class,
         projectParamsTest.getAccountIdentifier(), projectParamsTest.getOrgIdentifier());
-    verify(mockServiceLevelObjectiveService, times(3)).delete(any(), any());
+    verify(mockServiceLevelObjectiveService, times(3)).delete(any(), any(), anyBoolean());
   }
 
   @Test
@@ -2419,7 +2425,7 @@ public class ServiceLevelObjectiveV2ServiceImplTest extends CvNextGenTestBase {
 
     mockServiceLevelObjectiveService.deleteByAccountIdentifier(
         AbstractServiceLevelObjective.class, projectParamsTest.getAccountIdentifier());
-    verify(mockServiceLevelObjectiveService, times(3)).delete(any(), any());
+    verify(mockServiceLevelObjectiveService, times(3)).delete(any(), any(), anyBoolean());
   }
 
   @Test


### PR DESCRIPTION
* fix: [SRM-14706]: Delete for SLO is not happening if the project is deleted and the SLO is used in account level composite SLO

* Fix tests