### PR TITLE
fix:[CDS-68605]: Add NO_LIMIT to skip global limit configuration (#47446)

### DIFF
--- a/400-rest/src/main/java/software/wings/service/impl/artifact/ArtifactCollectionUtils.java
+++ b/400-rest/src/main/java/software/wings/service/impl/artifact/ArtifactCollectionUtils.java
@@ -15,6 +15,7 @@ import static io.harness.data.encoding.EncodingUtils.encodeBase64;
 import static io.harness.data.structure.EmptyPredicate.isEmpty;
 import static io.harness.data.structure.EmptyPredicate.isNotEmpty;
 import static io.harness.exception.WingsException.USER;
+import static io.harness.mongo.MongoConfig.NO_LIMIT;
 import static io.harness.validation.Validator.notNullCheck;
 
 import static software.wings.beans.CGConstants.GLOBAL_APP_ID;
@@ -826,8 +827,8 @@ public class ArtifactCollectionUtils {
     String artifactStreamType = artifactStream.getArtifactStreamType();
     Function<Artifact, String> keyFn = getArtifactKeyFn(artifactStreamType, artifactStreamAttributes);
     Set<String> artifactKeys = new HashSet<>();
-    try (HIterator<Artifact> artifacts =
-             new HIterator<>(artifactService.prepareArtifactWithMetadataQuery(artifactStream, true).fetch())) {
+    try (HIterator<Artifact> artifacts = new HIterator<>(
+             artifactService.prepareArtifactWithMetadataQuery(artifactStream, true).limit(NO_LIMIT).fetch())) {
       for (Artifact artifact : artifacts) {
         String key = keyFn.apply(artifact);
         if (key != null) {

--- a/400-rest/src/test/java/software/wings/service/impl/ArtifactCollectionUtilsTest.java
+++ b/400-rest/src/test/java/software/wings/service/impl/ArtifactCollectionUtilsTest.java
@@ -43,6 +43,7 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -121,6 +122,7 @@ public class ArtifactCollectionUtilsTest extends WingsBaseTest {
   public void setUp() {
     when(artifactService.prepareArtifactWithMetadataQuery(any(ArtifactStream.class), anyBoolean()))
         .thenReturn(artifactQuery);
+    when(artifactQuery.limit(anyInt())).thenReturn(artifactQuery);
     when(artifactQuery.fetch()).thenReturn(artifactIterator);
     when(artifactIterator.hasNext()).thenReturn(true).thenReturn(false);
     when(artifactIterator.next()).thenReturn(anArtifact().build());

--- a/400-rest/src/test/java/software/wings/service/impl/artifact/ArtifactCollectionServiceTest.java
+++ b/400-rest/src/test/java/software/wings/service/impl/artifact/ArtifactCollectionServiceTest.java
@@ -43,6 +43,7 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
@@ -894,6 +895,7 @@ public class ArtifactCollectionServiceTest extends WingsBaseTest {
     when(artifactStreamServiceBindingService.getService(APP_ID, ARTIFACT_STREAM_ID, true))
         .thenReturn(Service.builder().artifactType(ArtifactType.JAR).build());
     when(artifactService.prepareArtifactWithMetadataQuery(any(), anyBoolean())).thenReturn(query);
+    when(query.limit(anyInt())).thenReturn(query);
     when(query.fetch()).thenReturn(artifactIterator);
     when(artifactIterator.hasNext()).thenReturn(true).thenReturn(false);
     Map<String, String> map = new HashMap<>();
@@ -935,6 +937,7 @@ public class ArtifactCollectionServiceTest extends WingsBaseTest {
     when(artifactStreamServiceBindingService.getService(APP_ID, ARTIFACT_STREAM_ID, true))
         .thenReturn(Service.builder().artifactType(ArtifactType.WAR).build());
     when(artifactService.prepareArtifactWithMetadataQuery(any(), anyBoolean())).thenReturn(query);
+    when(query.limit(anyInt())).thenReturn(query);
     when(query.fetch()).thenReturn(artifactIterator);
     when(artifactIterator.hasNext()).thenReturn(true).thenReturn(false);
     Map<String, String> map = new HashMap<>();


### PR DESCRIPTION
* fix:[CDS-68605]: Add NO_LIMIT to skip global limit configuration

This query already uses HIterator and is optimized, I just added the NO_LIMIT to it.

* fix:[CDS-68605]: Fixed unit test