### PR TITLE
fix:[CDS-68606]: Add NO_LIMIT to skip global limit configuration (ResourceLookupSyncHandler/ResourceLookupServiceImpl) (#47447)

### DIFF
--- a/400-rest/src/main/java/software/wings/scheduler/ResourceLookupSyncHandler.java
+++ b/400-rest/src/main/java/software/wings/scheduler/ResourceLookupSyncHandler.java
@@ -8,6 +8,7 @@
 package software.wings.scheduler;
 
 import static io.harness.logging.AutoLogContext.OverrideBehavior.OVERRIDE_ERROR;
+import static io.harness.mongo.MongoConfig.NO_LIMIT;
 import static io.harness.mongo.iterator.MongoPersistenceIterator.SchedulingType.REGULAR;
 
 import static java.time.Duration.ofMinutes;
@@ -132,6 +133,7 @@ public class ResourceLookupSyncHandler extends IteratorPumpAndRedisModeHandler i
     try (HIterator<HarnessTagLink> tagLinksHIterator =
              new HIterator<>(wingsPersistence.createQuery(HarnessTagLink.class)
                                  .filter(HarnessTagLinkKeys.accountId, accountId)
+                                 .limit(NO_LIMIT)
                                  .fetch())) {
       while (tagLinksHIterator.hasNext()) {
         HarnessTagLink tagLink = tagLinksHIterator.next();


### PR DESCRIPTION
* fix:[CDS-68606]: Add NO_LIMIT to skip global limit configuration

This query already uses HIterator and is optimized, I just added the NO_LIMIT to it.

* fix:[CDS-68606]: Add projection to retrieve only two fields