### PR TITLE
[feat]: [PL-32740]: Handle single user failure in a user group sync for Ldap. (#47573)

### DIFF
--- a/120-ng-manager/modules/ldap/src/main/java/io/harness/ldap/scheduler/NGLdapGroupSyncHelper.java
+++ b/120-ng-manager/modules/ldap/src/main/java/io/harness/ldap/scheduler/NGLdapGroupSyncHelper.java
@@ -67,8 +67,9 @@ public class NGLdapGroupSyncHelper {
 
   private void reconcileUserGroupWithLdapGroup(
       UserGroup userGroup, LdapGroupResponse ldapGroup, String ssoId, List<UserGroup> failedUserGroups) {
-    log.info("NGLDAP: Starting sync for user group {}, in account {}, with corresponding ldap group dn {}",
-        userGroup.getIdentifier(), userGroup.getAccountIdentifier(), ldapGroup.getDn());
+    log.info(
+        "NGLDAP: Starting sync for user group {}, in account {}, with corresponding ldap group dn {}. The number of users returned for LdapGroup is: {}",
+        userGroup.getIdentifier(), userGroup.getAccountIdentifier(), ldapGroup.getDn(), ldapGroup.getTotalMembers());
     try {
       syncUserGroupMetadata(userGroup, ldapGroup);
       Set<String> ldapUserEmails = ldapGroup.getUsers()
@@ -76,6 +77,9 @@ public class NGLdapGroupSyncHelper {
                                        .map(LdapUserResponse::getEmail)
                                        .filter(Objects::nonNull)
                                        .collect(Collectors.toSet());
+
+      log.info("NGLDAP: Users email list received from LDAP on group dn {}, linked to user group {} are {}",
+          ldapGroup.getDn(), userGroup.getIdentifier(), getStringBuilderForEmails(ldapUserEmails).toString());
       List<UserInfo> usersInfo = new ArrayList<>();
 
       // can cause issue, check if our APIs support querying ~1K list of users
@@ -96,25 +100,36 @@ public class NGLdapGroupSyncHelper {
         }
       }
 
+      log.info(
+          "NGLDAP: Users email after getting user records from CG for user group {}, has received count: {} and are having emails as {}",
+          userGroup.getIdentifier(), userGroupUserEmails.size(),
+          getStringBuilderForEmails(userGroupUserEmails).toString());
+
       Set<String> usersToRemove = SetUtils.difference(userGroupUserEmails, ldapUserEmails);
       Set<String> usersToAdd = SetUtils.difference(ldapUserEmails, userGroupUserEmails);
 
       for (LdapUserResponse userResponse : ldapGroup.getUsers()) {
-        if (usersToAdd.contains(userResponse.getEmail())) {
-          // add to userGroup
-          addMemberToGroup(userGroup, userResponse);
-        } else {
-          // update user name
-          updateUserInGroup(userGroup, userResponse);
+        try {
+          if (usersToAdd.contains(userResponse.getEmail())) {
+            // add to userGroup
+            addMemberToGroup(userGroup, userResponse);
+          } else {
+            // update user name
+            updateUserInGroup(userGroup, userResponse);
+          }
+        } catch (Exception exception) {
+          log.error(
+              "NGLDAP: Skipping : Add/update user with ldap externalUserId {}, email: {} to User group: {} in account: {}, organization: {}, project: {} failed",
+              userResponse.getUserId(), userResponse.getEmail(), userGroup, userGroup.getAccountIdentifier(),
+              userGroup.getOrgIdentifier(), userGroup.getProjectIdentifier(), exception);
         }
       }
 
       if (isNotEmpty(usersToRemove)) {
-        // remove from userGroup
         removeUserFromGroup(userGroup, emailToUserInfoMap, usersToRemove);
       }
     } catch (Exception exc) {
-      log.error("NGLDAP: Sync Error while updating user Group or its users {} in account {} : ",
+      log.error("NGLDAP: Sync Error while updating user Group or its users {}: in account {} : ",
           userGroup.getIdentifier(), userGroup.getAccountIdentifier(), exc);
       failedUserGroups.add(userGroup);
     }
@@ -138,7 +153,14 @@ public class NGLdapGroupSyncHelper {
       if (isNotEmpty(userId)) {
         log.info("NGLDAP: removing user {}, from group: {} for account {}", userId, userGroup.getIdentifier(),
             userGroup.getAccountIdentifier());
-        userGroupService.removeMember(scope, userGroup.getIdentifier(), userId);
+        try {
+          userGroupService.removeMember(scope, userGroup.getIdentifier(), userId);
+        } catch (Exception exception) {
+          log.error(
+              "NGLDAP: Skipping : Remove user with harness userId {}, email: {} to User group: {} in account: {}, organization: {}, project: {} failed",
+              userId, emailStr, userGroup, userGroup.getAccountIdentifier(), userGroup.getOrgIdentifier(),
+              userGroup.getProjectIdentifier(), exception);
+        }
       }
     }
   }
@@ -176,16 +198,16 @@ public class NGLdapGroupSyncHelper {
           || !checkUserPartOfAccountInNg(userGroup.getAccountIdentifier(), userGroup.getOrgIdentifier(),
               userGroup.getProjectIdentifier(), userOptional.get())) {
         log.warn(
-            "NGLDAP: Invite user with id {} and with externalUserId {}, or adding user to scope- account: {}, organization: {}, project: {} failed",
-            userOptional.get().getUuid(), userResponse.getUserId(), userGroup.getAccountIdentifier(),
-            userGroup.getOrgIdentifier(), userGroup.getProjectIdentifier());
+            "NGLDAP: Invite user with ldap externalUserId {}, or adding user to scope- account: {}, organization: {}, project: {} failed",
+            userResponse.getUserId(), userGroup.getAccountIdentifier(), userGroup.getOrgIdentifier(),
+            userGroup.getProjectIdentifier());
         // throw here to be caught above and added to 'failedUserGroups' count
         throw new IllegalStateException("NGLDAP: Illegal state value of user to be added as member to user group");
       }
 
-      log.info("NGLDAP: adding new user {}, to group: {} in account {} and externalUserId {}",
-          userOptional.get().getUuid(), userGroup.getIdentifier(), userGroup.getAccountIdentifier(),
-          userResponse.getUserId());
+      log.info("NGLDAP: adding new user {} having email: {} to group: {} in account {} and externalUserId {}",
+          userOptional.get().getUuid(), userOptional.get().getEmail(), userGroup.getIdentifier(),
+          userGroup.getAccountIdentifier(), userResponse.getUserId());
       userGroupService.addMember(userGroup.getAccountIdentifier(), userGroup.getOrgIdentifier(),
           userGroup.getProjectIdentifier(), userGroup.getIdentifier(), userOptional.get().getUuid());
     }
@@ -235,5 +257,13 @@ public class NGLdapGroupSyncHelper {
     log.info("NGLDAP: Updating user group {} in account {} with name: {}", userGroup.getIdentifier(),
         userGroup.getAccountIdentifier(), groupResponse.getName());
     userGroupService.update(userGroupDTO);
+  }
+
+  private StringBuilder getStringBuilderForEmails(Set<String> emails) {
+    StringBuilder sb = new StringBuilder();
+    if (isNotEmpty(emails)) {
+      emails.forEach(id -> sb.append(id).append(" "));
+    }
+    return sb;
   }
 }

--- a/400-rest/src/main/java/software/wings/scheduler/LdapGroupSyncJobHelper.java
+++ b/400-rest/src/main/java/software/wings/scheduler/LdapGroupSyncJobHelper.java
@@ -296,6 +296,8 @@ public class LdapGroupSyncJobHelper {
                 "LDAPIterator: creating user invite for account {} and user Invite {} and user Groups {} and externalUserId {}",
                 accountId, userInvite.getEmail(), Lists.newArrayList(userGroups), ldapUserResponse.getUserId());
             userService.inviteUser(userInvite, false, true);
+            // Get the newly added user and add them to this user group
+            user = userService.getUserByEmail(ldapUserResponse.getEmail());
             userService.addUserToUserGroups(accountId, user, Lists.newArrayList(userGroups), true, true);
             log.info("LDAPIterator: adding new user {} to groups {}  in accountId {}", user.getUuid(),
                 Lists.newArrayList(userGroups), accountId);

--- a/400-rest/src/main/java/software/wings/service/impl/UserServiceImpl.java
+++ b/400-rest/src/main/java/software/wings/service/impl/UserServiceImpl.java
@@ -1489,7 +1489,7 @@ public class UserServiceImpl implements UserService {
     Account account = accountService.get(accountId);
 
     User user = getUserByEmail(userInvite.getEmail());
-    if (user == null) {
+    if (user == null && featureFlagService.isEnabled(FeatureName.LDAP_SYNC_WITH_USERID, accountId)) {
       user = getUserByUserId(account.getUuid(), userInvite.getExternalUserId());
     }
 

--- a/930-delegate-tasks/src/main/java/software/wings/service/impl/ldap/ExecuteLdapGroupsSearchRequest.java
+++ b/930-delegate-tasks/src/main/java/software/wings/service/impl/ldap/ExecuteLdapGroupsSearchRequest.java
@@ -44,7 +44,7 @@ public class ExecuteLdapGroupsSearchRequest implements Function<LdapListGroupsRe
       String defaultErrorMessage =
           String.format("LdapException occurred while searchGroupbyName for base %s and searchQuery %s",
               ldapSearch.getBaseDN(), ldapSearch.getSearchFilter());
-      log.error(defaultErrorMessage, le);
+      log.warn(defaultErrorMessage + " with exception: " + le.getMessage());
       searchStatusMessage = isNull(le.getMessage()) ? defaultErrorMessage : le.getMessage();
     }
 

--- a/930-delegate-tasks/src/main/java/software/wings/service/impl/ldap/ExecuteLdapUserExistsRequest.java
+++ b/930-delegate-tasks/src/main/java/software/wings/service/impl/ldap/ExecuteLdapUserExistsRequest.java
@@ -45,7 +45,7 @@ public class ExecuteLdapUserExistsRequest implements Function<LdapUserExistsRequ
       String defaultErrorMessage = String.format(
           "LdapException exception occurred when executing user exists request for baseDN = %s, searchFilter = %s",
           ldapUserConfig.getBaseDN(), ldapUserConfig.getSearchFilter());
-      log.error(defaultErrorMessage, le);
+      log.warn(defaultErrorMessage + " with exception: " + le.getMessage());
       searchStatus = Status.FAILURE;
       searchStatusMessage = isNull(le.getMessage()) ? defaultErrorMessage : le.getMessage();
     }


### PR DESCRIPTION
* [feat]: [PL-32740]: Handle single user failure in a user group sync for Ldap. (#47564)

* [fix]: [PL-32740]: hot fix to prod1: adding logs for NGLDAP scenarios of user Email difference

* [feat]: [PL-32740]: Handle single user failure in a user group sync for Ldap.

Signed-off-by: Shashank Singh <shashank.singh@harness.io>

* [feat]: [PL-32740]: Handle single user failure in a user group sync for Ldap.

Signed-off-by: Shashank Singh <shashank.singh@harness.io>

* [feat]: [PL-32740]: Handle single user failure in a user group sync for Ldap.

Signed-off-by: Shashank Singh <shashank.singh@harness.io>

* [feat]: [PL-32740]: Handle single user failure in a user group sync for Ldap.

Signed-off-by: Shashank Singh <shashank.singh@harness.io>

* [feat]: [PL-32740]: Handle single user failure in a user group sync for Ldap.

Signed-off-by: Shashank Singh <shashank.singh@harness.io>

* [feat]: [PL-32740]: Handle single user failure in a user group sync for Ldap.

Signed-off-by: Shashank Singh <shashank.singh@harness.io>

---------

Signed-off-by: Shashank Singh <shashank.singh@harness.io>
Co-authored-by: Prateek Barapatre <prateek.barapatre@harness.io>

* [feat]: [PL-32740]: Handle single user failure in a user group sync for Ldap.

Signed-off-by: Shashank Singh <shashank.singh@harness.io>

* [feat]: [PL-32740]: Handle single user failure in a user group sync for Ldap.

Signed-off-by: Shashank Singh <shashank.singh@harness.io>

---------

Signed-off-by: Shashank Singh <shashank.singh@harness.io>
Co-authored-by: Prateek Barapatre <prateek.barapatre@harness.io>