### PR TITLE
[fix]: [CDS-68312]: Added Task selectors to Jenkins Sync task (#47418)

### DIFF
--- a/125-cd-nextgen/src/main/java/io/harness/cdng/jenkins/jenkinsstep/JenkinsBuildStepHelperServiceImpl.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/jenkins/jenkinsstep/JenkinsBuildStepHelperServiceImpl.java
@@ -196,7 +196,7 @@ public class JenkinsBuildStepHelperServiceImpl implements JenkinsBuildStepHelper
             .taskSetupAbstraction("ng", "true")
             .taskSetupAbstraction("owner", ngAccess.getOrgIdentifier() + "/" + ngAccess.getProjectIdentifier())
             .taskSetupAbstraction("projectIdentifier", ngAccess.getProjectIdentifier())
-            .taskSelectors(delegateRequest.getJenkinsConnectorDTO().getDelegateSelectors())
+            .taskSelectors(delegateRequest.getDelegateSelectors())
             .logStreamingAbstractions(logAbstractionMap)
             .build();
     return delegateGrpcClientWrapper.executeSyncTaskV2(delegateTaskRequest);


### PR DESCRIPTION
* [CDS-68312]: Added Task selectors to Jenkins Sync task

* fix: [CDS-68312]: Do not pass params twice in the request

---------

Co-authored-by: Yogesh Chauhan <yogesh.chauhan@harness.io>