### PR TITLE
feat: [CDS-59370]: support infra tags in outcome (#47474)

### DIFF
--- a/125-cd-nextgen/src/main/java/io/harness/cdng/creator/variables/DeploymentStageVariableCreator.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/creator/variables/DeploymentStageVariableCreator.java
@@ -353,7 +353,8 @@ public class DeploymentStageVariableCreator extends AbstractStageVariableCreator
         infrastructureMapper.toOutcome(infrastructureConfig.getInfrastructureDefinitionConfig().getSpec(),
             new ProvisionerExpressionEvaluator(Collections.emptyMap()), EnvironmentOutcome.builder().build(),
             ServiceStepOutcome.builder().build(), infrastructureEntity.getAccountId(),
-            infrastructureEntity.getOrgIdentifier(), infrastructureEntity.getProjectIdentifier());
+            infrastructureEntity.getOrgIdentifier(), infrastructureEntity.getProjectIdentifier(),
+            infrastructureConfig.getInfrastructureDefinitionConfig().getTags());
 
     List<String> infraStepOutputExpressions =
         VariableCreatorHelper.getExpressionsInObject(infrastructureOutcome, OutputExpressionConstants.INFRA);

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/infra/InfrastructureOutcomeProvider.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/infra/InfrastructureOutcomeProvider.java
@@ -20,6 +20,7 @@ import io.harness.steps.environment.EnvironmentOutcome;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.Map;
 import javax.annotation.Nonnull;
 
 @Singleton
@@ -30,11 +31,11 @@ public class InfrastructureOutcomeProvider {
 
   public InfrastructureOutcome getOutcome(Ambiance ambiance, @Nonnull Infrastructure infrastructure,
       EnvironmentOutcome environmentOutcome, ServiceStepOutcome service, final String accountIdentifier,
-      final String orgIdentifier, final String projectIdentifier) {
+      final String orgIdentifier, final String projectIdentifier, Map<String, String> tags) {
     ProvisionerExpressionEvaluator expressionEvaluator =
         providerExpressionEvaluatorProvider.getProviderExpressionEvaluator(
             ambiance, infrastructure.getProvisionerStepIdentifier());
     return infrastructureMapper.toOutcome(infrastructure, expressionEvaluator, environmentOutcome, service,
-        accountIdentifier, orgIdentifier, projectIdentifier);
+        accountIdentifier, orgIdentifier, projectIdentifier, tags);
   }
 }

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/infra/steps/AbstractInfrastructureTaskExecutableStep.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/infra/steps/AbstractInfrastructureTaskExecutableStep.java
@@ -174,7 +174,7 @@ abstract class AbstractInfrastructureTaskExecutableStep {
   }
 
   protected TaskRequestData obtainTaskInternal(Ambiance ambiance, Infrastructure infrastructure,
-      NGLogCallback logCallback, Boolean addRcStep, boolean skipInstances) {
+      NGLogCallback logCallback, Boolean addRcStep, boolean skipInstances, Map<String, String> tags) {
     saveExecutionLog(logCallback, "Starting infrastructure step...");
 
     validateConnector(infrastructure, ambiance, logCallback);
@@ -190,7 +190,7 @@ abstract class AbstractInfrastructureTaskExecutableStep {
 
     final InfrastructureOutcome infrastructureOutcome =
         infrastructureOutcomeProvider.getOutcome(ambiance, infrastructure, environmentOutcome, serviceOutcome,
-            ngAccess.getAccountIdentifier(), ngAccess.getOrgIdentifier(), ngAccess.getProjectIdentifier());
+            ngAccess.getAccountIdentifier(), ngAccess.getOrgIdentifier(), ngAccess.getProjectIdentifier(), tags);
 
     executionSweepingOutputService.consume(ambiance, INFRA_TASK_EXECUTABLE_STEP_OUTPUT,
         InfrastructureTaskExecutableStepSweepingOutput.builder()

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/infra/steps/InfrastructureStep.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/infra/steps/InfrastructureStep.java
@@ -118,6 +118,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -177,9 +178,9 @@ public class InfrastructureStep implements SyncExecutableWithRbac<Infrastructure
 
     infrastructureValidator.validate(infrastructure);
 
-    final InfrastructureOutcome infrastructureOutcome =
-        infrastructureOutcomeProvider.getOutcome(ambiance, infrastructure, environmentOutcome, serviceOutcome,
-            ngAccess.getAccountIdentifier(), ngAccess.getOrgIdentifier(), ngAccess.getProjectIdentifier());
+    final InfrastructureOutcome infrastructureOutcome = infrastructureOutcomeProvider.getOutcome(ambiance,
+        infrastructure, environmentOutcome, serviceOutcome, ngAccess.getAccountIdentifier(),
+        ngAccess.getOrgIdentifier(), ngAccess.getProjectIdentifier(), new HashMap<>());
 
     if (environmentOutcome != null) {
       if (isNotEmpty(environmentOutcome.getName())) {

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/infra/steps/InfrastructureTaskExecutableStep.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/infra/steps/InfrastructureTaskExecutableStep.java
@@ -33,6 +33,7 @@ import io.harness.supplier.ThrowingSupplier;
 import io.harness.utils.NGFeatureFlagHelperService;
 
 import com.google.inject.Inject;
+import java.util.HashMap;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 
@@ -66,8 +67,8 @@ public class InfrastructureTaskExecutableStep extends AbstractInfrastructureTask
   public TaskRequest obtainTaskAfterRbac(
       Ambiance ambiance, Infrastructure infrastructureSpec, StepInputPackage inputPackage) {
     final NGLogCallback logCallback = infrastructureStepHelper.getInfrastructureLogCallback(ambiance, true, "Execute");
-    return obtainTaskInternal(
-        ambiance, infrastructureSpec, logCallback, null, infrastructureStepHelper.getSkipInstances(infrastructureSpec))
+    return obtainTaskInternal(ambiance, infrastructureSpec, logCallback, null,
+        infrastructureStepHelper.getSkipInstances(infrastructureSpec), new HashMap<>())
         .getTaskRequest();
   }
 

--- a/125-cd-nextgen/src/main/java/io/harness/cdng/infra/steps/InfrastructureTaskExecutableStepV2.java
+++ b/125-cd-nextgen/src/main/java/io/harness/cdng/infra/steps/InfrastructureTaskExecutableStepV2.java
@@ -174,7 +174,8 @@ public class InfrastructureTaskExecutableStepV2 extends AbstractInfrastructureTa
     // Create delegate task for infra if needed
     if (isTaskStep(infraSpec.getKind())) {
       final TaskRequestData taskRequest = obtainTaskInternal(ambiance, infraSpec, logCallback,
-          !infrastructureConfig.getInfrastructureDefinitionConfig().isAllowSimultaneousDeployments(), skipInstances);
+          !infrastructureConfig.getInfrastructureDefinitionConfig().isAllowSimultaneousDeployments(), skipInstances,
+          infrastructureConfig.getInfrastructureDefinitionConfig().getTags());
       final DelegateTaskRequest delegateTaskRequest =
           cdStepHelper.mapTaskRequestToDelegateTaskRequest(taskRequest.getTaskRequest(), taskRequest.getTaskData(),
               CollectionUtils.emptyIfNull(taskRequest.getTaskSelectorYamls())
@@ -335,9 +336,9 @@ public class InfrastructureTaskExecutableStepV2 extends AbstractInfrastructureTa
 
     infrastructureValidator.validate(spec);
 
-    final InfrastructureOutcome infrastructureOutcome =
-        infrastructureOutcomeProvider.getOutcome(ambiance, spec, environmentOutcome, serviceOutcome,
-            ngAccess.getAccountIdentifier(), ngAccess.getOrgIdentifier(), ngAccess.getProjectIdentifier());
+    final InfrastructureOutcome infrastructureOutcome = infrastructureOutcomeProvider.getOutcome(ambiance, spec,
+        environmentOutcome, serviceOutcome, ngAccess.getAccountIdentifier(), ngAccess.getOrgIdentifier(),
+        ngAccess.getProjectIdentifier(), infrastructure.getInfrastructureDefinitionConfig().getTags());
 
     // save spec sweeping output for further use within the step
     executionSweepingOutputService.consume(ambiance, INFRA_TASK_EXECUTABLE_STEP_OUTPUT,

--- a/125-cd-nextgen/src/test/java/io/harness/cdng/creator/variables/DeploymentStageVariableCreatorTest.java
+++ b/125-cd-nextgen/src/test/java/io/harness/cdng/creator/variables/DeploymentStageVariableCreatorTest.java
@@ -455,7 +455,7 @@ public class DeploymentStageVariableCreatorTest extends CategoryTest {
                 List.of("env.name", "env.identifier", "env.description", "env.type", "env.tags", "env.environmentRef",
                     "env.variables.envVar1", "env.variables.svar1", "env.envGroupRef", "env.envGroupName"))
             .expectedInfraFqn(List.of("infra.connectorRef", "infra.namespace", "infra.releaseName",
-                "infra.infrastructureKey", "infra.connector"))
+                "infra.infrastructureKey", "infra.connector", "infra.tags"))
             .envFqnIndex(0)
             .infraFqnIndex(1)
             .svcFqnIndex(2)
@@ -483,7 +483,7 @@ public class DeploymentStageVariableCreatorTest extends CategoryTest {
                 List.of("env.name", "env.identifier", "env.description", "env.type", "env.tags", "env.environmentRef",
                     "env.variables.envVar1", "env.variables.svar1", "env.envGroupRef", "env.envGroupName"))
             .expectedInfraFqn(List.of("infra.connectorRef", "infra.namespace", "infra.releaseName",
-                "infra.infrastructureKey", "infra.connector"))
+                "infra.infrastructureKey", "infra.connector", "infra.tags"))
             .provisionerDependencyIndex(-1)
             .envFqnIndex(0)
             .infraFqnIndex(1)
@@ -522,7 +522,7 @@ public class DeploymentStageVariableCreatorTest extends CategoryTest {
                 List.of("env.name", "env.identifier", "env.description", "env.type", "env.tags", "env.environmentRef",
                     "env.variables.envVar1", "env.variables.svar1", "env.envGroupRef", "env.envGroupName"))
             .expectedInfraFqn(List.of("infra.connectorRef", "infra.namespace", "infra.releaseName",
-                "infra.infrastructureKey", "infra.connector"))
+                "infra.infrastructureKey", "infra.connector", "infra.tags"))
             .provisionerDependencyIndex(-1)
             .envFqnIndex(0)
             .infraFqnIndex(1)
@@ -561,7 +561,7 @@ public class DeploymentStageVariableCreatorTest extends CategoryTest {
                 List.of("env.name", "env.identifier", "env.description", "env.type", "env.tags", "env.environmentRef",
                     "env.variables.envVar1", "env.variables.svar1", "env.envGroupRef", "env.envGroupName"))
             .expectedInfraFqn(List.of("infra.connectorRef", "infra.namespace", "infra.releaseName",
-                "infra.infrastructureKey", "infra.connector"))
+                "infra.infrastructureKey", "infra.connector", "infra.tags"))
             .provisionerDependencyIndex(0)
             .envFqnIndex(1)
             .infraFqnIndex(2)
@@ -601,7 +601,7 @@ public class DeploymentStageVariableCreatorTest extends CategoryTest {
                 List.of("env.name", "env.identifier", "env.description", "env.type", "env.tags", "env.environmentRef",
                     "env.variables.envVar1", "env.variables.svar1", "env.envGroupRef", "env.envGroupName"))
             .expectedInfraFqn(List.of("infra.connectorRef", "infra.namespace", "infra.releaseName",
-                "infra.infrastructureKey", "infra.connector"))
+                "infra.infrastructureKey", "infra.connector", "infra.tags"))
             .provisionerDependencyIndex(-1)
             .envFqnIndex(0)
             .infraFqnIndex(1)

--- a/125-cd-nextgen/src/test/java/io/harness/cdng/infra/InfrastructureMapperTest.java
+++ b/125-cd-nextgen/src/test/java/io/harness/cdng/infra/InfrastructureMapperTest.java
@@ -77,6 +77,8 @@ import io.harness.steps.environment.EnvironmentOutcome;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.After;
 import org.junit.Before;
@@ -133,8 +135,9 @@ public class InfrastructureMapperTest extends CategoryTest {
             .infrastructureKey("11f6673d11711af46238bf33972cb99a4a869244")
             .build();
 
-    InfrastructureOutcome infrastructureOutcome = infrastructureMapper.toOutcome(k8SDirectInfrastructure,
-        getEmptyProvisionerExpressionEvaluator(), environment, serviceOutcome, "accountId", "projId", "orgId");
+    InfrastructureOutcome infrastructureOutcome =
+        infrastructureMapper.toOutcome(k8SDirectInfrastructure, getEmptyProvisionerExpressionEvaluator(), environment,
+            serviceOutcome, "accountId", "projId", "orgId", new HashMap<>());
     InfrastructureOutcomeAbstract infrastructureOutcomeAbstract = (InfrastructureOutcomeAbstract) infrastructureOutcome;
     assertThat(infrastructureOutcomeAbstract.getName()).isEqualTo("infraName");
     assertThat(infrastructureOutcome).isEqualTo(k8sDirectInfrastructureOutcome);
@@ -161,8 +164,9 @@ public class InfrastructureMapperTest extends CategoryTest {
             .infrastructureKey("11f6673d11711af46238bf33972cb99a4a869244")
             .build();
 
-    InfrastructureOutcome infrastructureOutcome = infrastructureMapper.toOutcome(k8SDirectInfrastructure,
-        getEmptyProvisionerExpressionEvaluator(), environment, serviceOutcome, "accountId", "projId", "orgId");
+    InfrastructureOutcome infrastructureOutcome =
+        infrastructureMapper.toOutcome(k8SDirectInfrastructure, getEmptyProvisionerExpressionEvaluator(), environment,
+            serviceOutcome, "accountId", "projId", "orgId", new HashMap<>());
     assertThat(infrastructureOutcome).isEqualTo(k8sDirectInfrastructureOutcome);
     assertThat(infrastructureOutcome.getConnector()).isNull();
   }
@@ -188,8 +192,9 @@ public class InfrastructureMapperTest extends CategoryTest {
             .infrastructureKey("54874007d7082ff0ab54cd51865954f5e78c5c88")
             .build();
 
-    InfrastructureOutcome infrastructureOutcome = infrastructureMapper.toOutcome(k8SGcpInfrastructure,
-        getEmptyProvisionerExpressionEvaluator(), environment, serviceOutcome, "accountId", "projId", "orgId");
+    InfrastructureOutcome infrastructureOutcome =
+        infrastructureMapper.toOutcome(k8SGcpInfrastructure, getEmptyProvisionerExpressionEvaluator(), environment,
+            serviceOutcome, "accountId", "projId", "orgId", new HashMap<>());
     assertThat(infrastructureOutcome).isEqualTo(k8sGcpInfrastructureOutcome);
   }
 
@@ -215,8 +220,9 @@ public class InfrastructureMapperTest extends CategoryTest {
 
     expectedOutcome.setConnector(Connector.builder().name("my_connector").build());
 
-    InfrastructureOutcome infrastructureOutcome = infrastructureMapper.toOutcome(serverlessAwsLambdaInfrastructure,
-        getEmptyProvisionerExpressionEvaluator(), environment, serviceOutcome, "accountId", "projId", "orgId");
+    InfrastructureOutcome infrastructureOutcome =
+        infrastructureMapper.toOutcome(serverlessAwsLambdaInfrastructure, getEmptyProvisionerExpressionEvaluator(),
+            environment, serviceOutcome, "accountId", "projId", "orgId", new HashMap<>());
     assertThat(infrastructureOutcome).isEqualTo(expectedOutcome);
   }
 
@@ -244,8 +250,9 @@ public class InfrastructureMapperTest extends CategoryTest {
 
     expectedOutcome.setConnector(Connector.builder().name("my_connector").build());
 
-    InfrastructureOutcome infrastructureOutcome = infrastructureMapper.toOutcome(infrastructure,
-        getEmptyProvisionerExpressionEvaluator(), environment, serviceOutcome, "accountId", "projId", "orgId");
+    InfrastructureOutcome infrastructureOutcome =
+        infrastructureMapper.toOutcome(infrastructure, getEmptyProvisionerExpressionEvaluator(), environment,
+            serviceOutcome, "accountId", "projId", "orgId", new HashMap<>());
     assertThat(infrastructureOutcome).isEqualTo(expectedOutcome);
   }
 
@@ -265,8 +272,9 @@ public class InfrastructureMapperTest extends CategoryTest {
                             .build())
             .build();
 
-    InfrastructureOutcome infrastructureOutcome = infrastructureMapper.toOutcome(infrastructure,
-        getEmptyProvisionerExpressionEvaluator(), environment, serviceOutcome, "accountId", "projId", "orgId");
+    InfrastructureOutcome infrastructureOutcome =
+        infrastructureMapper.toOutcome(infrastructure, getEmptyProvisionerExpressionEvaluator(), environment,
+            serviceOutcome, "accountId", "projId", "orgId", new HashMap<>());
 
     PdcInfrastructureOutcome outcome =
         PdcInfrastructureOutcome.builder()
@@ -295,19 +303,19 @@ public class InfrastructureMapperTest extends CategoryTest {
             .hosts(ParameterField.createValueField(Arrays.asList("host1", "host2", "host3")))
             .build();
 
-    InfrastructureOutcome infrastructureOutcome = infrastructureMapper.toOutcome(infrastructure,
-        getEmptyProvisionerExpressionEvaluator(), environment, serviceOutcome, "accountId", "projId", "orgId");
+    InfrastructureOutcome infrastructureOutcome =
+        infrastructureMapper.toOutcome(infrastructure, getEmptyProvisionerExpressionEvaluator(), environment,
+            serviceOutcome, "accountId", "projId", "orgId", new HashMap<>());
+    PdcInfrastructureOutcome pdcInfrastructureOutcome =
+        PdcInfrastructureOutcome.builder()
+            .credentialsRef("ssh-key-ref")
+            .hosts(Arrays.asList("host1", "host2", "host3"))
+            .environment(environment)
+            .hostFilter(
+                HostFilterDTO.builder().spec(AllHostsFilterDTO.builder().build()).type(HostFilterType.ALL).build())
+            .build();
 
-    assertThat(infrastructureOutcome)
-        .isEqualToIgnoringGivenFields(
-            PdcInfrastructureOutcome.builder()
-                .credentialsRef("ssh-key-ref")
-                .hosts(Arrays.asList("host1", "host2", "host3"))
-                .environment(environment)
-                .hostFilter(
-                    HostFilterDTO.builder().spec(AllHostsFilterDTO.builder().build()).type(HostFilterType.ALL).build())
-                .build(),
-            "infrastructureKey");
+    assertThat(infrastructureOutcome).isEqualToIgnoringGivenFields(pdcInfrastructureOutcome, "infrastructureKey");
   }
 
   @Test
@@ -324,19 +332,22 @@ public class InfrastructureMapperTest extends CategoryTest {
             .hostConnectionType(ParameterField.createValueField("Hostname"))
             .build();
 
-    InfrastructureOutcome infrastructureOutcome = infrastructureMapper.toOutcome(infrastructure,
-        getEmptyProvisionerExpressionEvaluator(), environment, serviceOutcome, "accountId", "projId", "orgId");
+    InfrastructureOutcome infrastructureOutcome =
+        infrastructureMapper.toOutcome(infrastructure, getEmptyProvisionerExpressionEvaluator(), environment,
+            serviceOutcome, "accountId", "projId", "orgId", Map.of("entityKey", "entityValue"));
 
     SshWinRmAzureInfrastructureOutcome outcome = SshWinRmAzureInfrastructureOutcome.builder()
                                                      .connectorRef("connector-ref")
                                                      .credentialsRef("credentials-ref")
                                                      .resourceGroup("res-group")
                                                      .subscriptionId("sub-id")
-                                                     .tags(Collections.singletonMap("tag", "val"))
+                                                     .hostTags(Collections.singletonMap("tag", "val"))
                                                      .hostConnectionType("Hostname")
                                                      .environment(environment)
                                                      .build();
     outcome.setConnector(Connector.builder().name("my_connector").build());
+    // outcomes contains merged tags from aws and entity
+    outcome.setTags(Map.of("tag", "val", "entityKey", "entityValue"));
     assertThat(infrastructureOutcome).isEqualToIgnoringGivenFields(outcome, "infrastructureKey");
   }
 
@@ -369,7 +380,7 @@ public class InfrastructureMapperTest extends CategoryTest {
             .build();
 
     assertThat(infrastructureMapper.toOutcome(k8SAzureInfrastructure, getEmptyProvisionerExpressionEvaluator(),
-                   environment, serviceOutcome, "accountId", "projId", "orgId"))
+                   environment, serviceOutcome, "accountId", "projId", "orgId", new HashMap<>()))
         .isEqualTo(k8sAzureInfrastructureOutcome);
 
     k8SAzureInfrastructure = K8sAzureInfrastructure.builder()
@@ -395,7 +406,7 @@ public class InfrastructureMapperTest extends CategoryTest {
                                         .build();
 
     assertThat(infrastructureMapper.toOutcome(k8SAzureInfrastructure, getEmptyProvisionerExpressionEvaluator(),
-                   environment, serviceOutcome, "accountId", "projId", "orgId"))
+                   environment, serviceOutcome, "accountId", "projId", "orgId", new HashMap<>()))
         .isEqualTo(k8sAzureInfrastructureOutcome);
   }
 
@@ -410,8 +421,9 @@ public class InfrastructureMapperTest extends CategoryTest {
             .resourceGroup(ParameterField.createValueField("resourceGroup"))
             .build();
 
-    InfrastructureOutcome infrastructureOutcome = infrastructureMapper.toOutcome(azureWebAppInfrastructure,
-        getEmptyProvisionerExpressionEvaluator(), environment, serviceOutcome, "accountId", "projId", "orgId");
+    InfrastructureOutcome infrastructureOutcome =
+        infrastructureMapper.toOutcome(azureWebAppInfrastructure, getEmptyProvisionerExpressionEvaluator(), environment,
+            serviceOutcome, "accountId", "projId", "orgId", new HashMap<>());
     AzureWebAppInfrastructureOutcome outcome = AzureWebAppInfrastructureOutcome.builder()
                                                    .connectorRef("connectorId")
                                                    .subscription("subscriptionId")
@@ -448,8 +460,9 @@ public class InfrastructureMapperTest extends CategoryTest {
 
     expectedOutcome.setConnector(Connector.builder().name("my_connector").build());
 
-    InfrastructureOutcome infrastructureOutcome = infrastructureMapper.toOutcome(tanzuApplicationServiceInfrastructure,
-        getEmptyProvisionerExpressionEvaluator(), environment, serviceOutcome, "accountId", "orgId", "projectId");
+    InfrastructureOutcome infrastructureOutcome =
+        infrastructureMapper.toOutcome(tanzuApplicationServiceInfrastructure, getEmptyProvisionerExpressionEvaluator(),
+            environment, serviceOutcome, "accountId", "orgId", "projectId", new HashMap<>());
 
     assertThat(infrastructureOutcome).isEqualTo(expectedOutcome);
   }
@@ -474,8 +487,9 @@ public class InfrastructureMapperTest extends CategoryTest {
 
     expectedOutcome.setConnector(Connector.builder().name("my_connector").build());
 
-    InfrastructureOutcome infrastructureOutcome = infrastructureMapper.toOutcome(ecsInfrastructure,
-        getEmptyProvisionerExpressionEvaluator(), environment, serviceOutcome, "accountId", "projId", "orgId");
+    InfrastructureOutcome infrastructureOutcome =
+        infrastructureMapper.toOutcome(ecsInfrastructure, getEmptyProvisionerExpressionEvaluator(), environment,
+            serviceOutcome, "accountId", "projId", "orgId", new HashMap<>());
     assertThat(infrastructureOutcome).isEqualTo(expectedOutcome);
   }
 
@@ -497,8 +511,9 @@ public class InfrastructureMapperTest extends CategoryTest {
 
     expectedOutcome.setConnector(Connector.builder().name("my_connector").build());
 
-    InfrastructureOutcome infrastructureOutcome = infrastructureMapper.toOutcome(asgInfrastructure,
-        getEmptyProvisionerExpressionEvaluator(), environment, serviceOutcome, "accountId", "projId", "orgId");
+    InfrastructureOutcome infrastructureOutcome =
+        infrastructureMapper.toOutcome(asgInfrastructure, getEmptyProvisionerExpressionEvaluator(), environment,
+            serviceOutcome, "accountId", "projId", "orgId", new HashMap<>());
     assertThat(infrastructureOutcome).isEqualTo(expectedOutcome);
   }
 
@@ -523,8 +538,9 @@ public class InfrastructureMapperTest extends CategoryTest {
             .infrastructureKey("54874007d7082ff0ab54cd51865954f5e78c5c88")
             .build();
 
-    InfrastructureOutcome infrastructureOutcome = infrastructureMapper.toOutcome(k8sAwsInfrastructure,
-        getEmptyProvisionerExpressionEvaluator(), environment, serviceOutcome, "accountId", "projId", "orgId");
+    InfrastructureOutcome infrastructureOutcome =
+        infrastructureMapper.toOutcome(k8sAwsInfrastructure, getEmptyProvisionerExpressionEvaluator(), environment,
+            serviceOutcome, "accountId", "projId", "orgId", new HashMap<>());
     assertThat(infrastructureOutcome).isEqualTo(k8sAwsInfrastructureOutcome);
   }
 
@@ -548,8 +564,9 @@ public class InfrastructureMapperTest extends CategoryTest {
             .infrastructureKey("9de2869e6ff4a3ec81fa7805b9a6fed5267906fe")
             .build();
 
-    InfrastructureOutcome infrastructureOutcome = infrastructureMapper.toOutcome(googleFunctionsInfrastructure,
-        getEmptyProvisionerExpressionEvaluator(), environment, serviceOutcome, "accountId", "projId", "orgId");
+    InfrastructureOutcome infrastructureOutcome =
+        infrastructureMapper.toOutcome(googleFunctionsInfrastructure, getEmptyProvisionerExpressionEvaluator(),
+            environment, serviceOutcome, "accountId", "projId", "orgId", new HashMap<>());
     assertThat(infrastructureOutcome).isEqualTo(googleFunctionsInfrastructureOutcome);
   }
 
@@ -561,6 +578,36 @@ public class InfrastructureMapperTest extends CategoryTest {
     infrastructureMapper.setInfraIdentifierAndName(k8SDirectInfrastructureOutcome, "Identifier", "Name");
     assertThat(k8SDirectInfrastructureOutcome.getInfraIdentifier()).isEqualTo("Identifier");
     assertThat(k8SDirectInfrastructureOutcome.getInfraName()).isEqualTo("Name");
+  }
+
+  @Test
+  @Owner(developers = ACASIAN)
+  @Category(UnitTests.class)
+  public void testK8sGcpInfraMapperWithTags() {
+    Map<String, String> tags = Map.of("type", "k8sGCP", "geo", "india", "prod", "");
+
+    K8sGcpInfrastructure k8SGcpInfrastructure = K8sGcpInfrastructure.builder()
+                                                    .connectorRef(ParameterField.createValueField("connectorId"))
+                                                    .namespace(ParameterField.createValueField("namespace"))
+                                                    .releaseName(ParameterField.createValueField("release"))
+                                                    .cluster(ParameterField.createValueField("cluster"))
+                                                    .build();
+
+    K8sGcpInfrastructureOutcome k8sGcpInfrastructureOutcome =
+        K8sGcpInfrastructureOutcome.builder()
+            .connectorRef("connectorId")
+            .namespace("namespace")
+            .releaseName("release")
+            .cluster("cluster")
+            .environment(environment)
+            .infrastructureKey("54874007d7082ff0ab54cd51865954f5e78c5c88")
+            .build();
+
+    k8sGcpInfrastructureOutcome.setTags(tags);
+
+    InfrastructureOutcome infrastructureOutcome = infrastructureMapper.toOutcome(k8SGcpInfrastructure,
+        getEmptyProvisionerExpressionEvaluator(), environment, serviceOutcome, "accountId", "projId", "orgId", tags);
+    assertThat(infrastructureOutcome).isEqualTo(k8sGcpInfrastructureOutcome);
   }
 
   private ProvisionerExpressionEvaluator getEmptyProvisionerExpressionEvaluator() {

--- a/125-cd-nextgen/src/test/java/io/harness/cdng/infra/steps/InfrastructureStepTest.java
+++ b/125-cd-nextgen/src/test/java/io/harness/cdng/infra/steps/InfrastructureStepTest.java
@@ -28,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeast;
@@ -230,7 +231,7 @@ public class InfrastructureStepTest extends CategoryTest {
     when(outcomeService.resolve(any(), eq(RefObjectUtils.getOutcomeRefObject(OutcomeExpressionConstants.SERVICE))))
         .thenReturn(ServiceStepOutcome.builder().type(ServiceSpecType.KUBERNETES).build());
     when(cdStepHelper.getK8sInfraDelegateConfig(any(), eq(ambiance))).thenReturn(k8sInfraDelegateConfig);
-    when(infrastructureOutcomeProvider.getOutcome(any(), any(), any(), any(), any(), any(), any()))
+    when(infrastructureOutcomeProvider.getOutcome(any(), any(), any(), any(), any(), any(), any(), anyMap()))
         .thenReturn(
             PdcInfrastructureOutcome.builder()
                 .credentialsRef("sshKeyRef")
@@ -278,7 +279,7 @@ public class InfrastructureStepTest extends CategoryTest {
     doNothing()
         .when(stageExecutionHelper)
         .saveStageExecutionInfo(eq(ambiance), any(ExecutionInfoKey.class), eq(InfrastructureKind.PDC));
-    when(infrastructureOutcomeProvider.getOutcome(any(), any(), any(), any(), any(), any(), any()))
+    when(infrastructureOutcomeProvider.getOutcome(any(), any(), any(), any(), any(), any(), any(), anyMap()))
         .thenReturn(
             PdcInfrastructureOutcome.builder()
                 .credentialsRef("sshKeyRef")
@@ -330,7 +331,7 @@ public class InfrastructureStepTest extends CategoryTest {
     when(outcomeService.resolve(any(), eq(RefObjectUtils.getOutcomeRefObject(OutcomeExpressionConstants.SERVICE))))
         .thenReturn(ServiceStepOutcome.builder().type(ServiceSpecType.WINRM).build());
     when(cdStepHelper.getWinRmInfraDelegateConfig(any(), eq(ambiance))).thenReturn(pdcWinRmInfraDelegateConfig);
-    when(infrastructureOutcomeProvider.getOutcome(any(), any(), any(), any(), any(), any(), any()))
+    when(infrastructureOutcomeProvider.getOutcome(any(), any(), any(), any(), any(), any(), any(), anyMap()))
         .thenReturn(
             PdcInfrastructureOutcome.builder()
                 .credentialsRef("sshKeyRef")

--- a/125-cd-nextgen/src/test/java/io/harness/cdng/infra/steps/InfrastructureTaskExecutableStepTest.java
+++ b/125-cd-nextgen/src/test/java/io/harness/cdng/infra/steps/InfrastructureTaskExecutableStepTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -224,12 +225,12 @@ public class InfrastructureTaskExecutableStepTest extends CategoryTest {
     when(outcomeService.resolve(any(), eq(RefObjectUtils.getOutcomeRefObject(OutcomeExpressionConstants.SERVICE))))
         .thenReturn(ServiceStepOutcome.builder().type(ServiceSpecType.SSH).build());
     when(cdStepHelper.getSshInfraDelegateConfig(any(), eq(ambiance))).thenReturn(azureSshInfraDelegateConfig);
-    when(infrastructureOutcomeProvider.getOutcome(any(), any(), any(), any(), any(), any(), any()))
+    when(infrastructureOutcomeProvider.getOutcome(any(), any(), any(), any(), any(), any(), any(), anyMap()))
         .thenReturn(SshWinRmAzureInfrastructureOutcome.builder()
                         .connectorRef("connectorRef")
                         .subscriptionId("subscriptionId")
                         .hostConnectionType("Hostname")
-                        .tags(Map.of("Env", "Dev"))
+                        .hostTags(Map.of("Env", "Dev"))
                         .credentialsRef("sshKeyRef")
                         .environment(EnvironmentOutcome.builder().build())
                         .infrastructureKey("572beaec293c79ba725f68bea0a8a1c7806dc878")
@@ -259,12 +260,12 @@ public class InfrastructureTaskExecutableStepTest extends CategoryTest {
     when(outcomeService.resolve(any(), eq(RefObjectUtils.getOutcomeRefObject(OutcomeExpressionConstants.SERVICE))))
         .thenReturn(ServiceStepOutcome.builder().type(ServiceSpecType.SSH).build());
     when(cdStepHelper.getSshInfraDelegateConfig(any(), eq(ambiance))).thenReturn(awsSshInfraDelegateConfig);
-    when(infrastructureOutcomeProvider.getOutcome(any(), any(), any(), any(), any(), any(), any()))
+    when(infrastructureOutcomeProvider.getOutcome(any(), any(), any(), any(), any(), any(), any(), anyMap()))
         .thenReturn(SshWinRmAwsInfrastructureOutcome.builder()
                         .connectorRef("connectorRef")
                         .region("region")
                         .hostConnectionType("Hostname")
-                        .tags(Map.of("testTag", "test"))
+                        .hostTags(Map.of("testTag", "test"))
                         .credentialsRef("sshKeyRef")
                         .environment(EnvironmentOutcome.builder().build())
                         .infrastructureKey("70dd2bc5aa8fc8920b04247e4151e8e1074332d3")
@@ -294,12 +295,12 @@ public class InfrastructureTaskExecutableStepTest extends CategoryTest {
     when(outcomeService.resolve(any(), eq(RefObjectUtils.getOutcomeRefObject(OutcomeExpressionConstants.SERVICE))))
         .thenReturn(ServiceStepOutcome.builder().type(ServiceSpecType.WINRM).build());
     when(cdStepHelper.getWinRmInfraDelegateConfig(any(), eq(ambiance))).thenReturn(azureWinrmInfraDelegateConfig);
-    when(infrastructureOutcomeProvider.getOutcome(any(), any(), any(), any(), any(), any(), any()))
+    when(infrastructureOutcomeProvider.getOutcome(any(), any(), any(), any(), any(), any(), any(), anyMap()))
         .thenReturn(SshWinRmAzureInfrastructureOutcome.builder()
                         .connectorRef("connectorRef")
                         .subscriptionId("subscriptionId")
                         .resourceGroup("resourceGroup")
-                        .tags(Map.of("Env", "Dev"))
+                        .hostTags(Map.of("Env", "Dev"))
                         .credentialsRef("sshKeyRef")
                         .environment(EnvironmentOutcome.builder().build())
                         .infrastructureKey("572beaec293c79ba725f68bea0a8a1c7806dc878")
@@ -329,12 +330,12 @@ public class InfrastructureTaskExecutableStepTest extends CategoryTest {
     when(outcomeService.resolve(any(), eq(RefObjectUtils.getOutcomeRefObject(OutcomeExpressionConstants.SERVICE))))
         .thenReturn(ServiceStepOutcome.builder().type(ServiceSpecType.WINRM).build());
     when(cdStepHelper.getWinRmInfraDelegateConfig(any(), eq(ambiance))).thenReturn(awsWinrmInfraDelegateConfig);
-    when(infrastructureOutcomeProvider.getOutcome(any(), any(), any(), any(), any(), any(), any()))
+    when(infrastructureOutcomeProvider.getOutcome(any(), any(), any(), any(), any(), any(), any(), anyMap()))
         .thenReturn(SshWinRmAwsInfrastructureOutcome.builder()
                         .connectorRef("connectorRef")
                         .credentialsRef("sshKeyRef")
                         .region("regionId")
-                        .tags(Map.of("testTag", "test"))
+                        .hostTags(Map.of("testTag", "test"))
                         .hostConnectionType("Hostname")
                         .environment(EnvironmentOutcome.builder().build())
                         .infrastructureKey("70dd2bc5aa8fc8920b04247e4151e8e1074332d3")

--- a/125-cd-nextgen/src/test/java/io/harness/cdng/infra/steps/InfrastructureTaskExecutableStepV2Test.java
+++ b/125-cd-nextgen/src/test/java/io/harness/cdng/infra/steps/InfrastructureTaskExecutableStepV2Test.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -426,7 +427,7 @@ public class InfrastructureTaskExecutableStepV2Test extends CategoryTest {
             .build())
         .when(cdStepHelper)
         .getSshInfraDelegateConfig(any(InfrastructureOutcome.class), any(Ambiance.class));
-    when(infrastructureOutcomeProvider.getOutcome(any(), any(), any(), any(), any(), any(), any()))
+    when(infrastructureOutcomeProvider.getOutcome(any(), any(), any(), any(), any(), any(), any(), anyMap()))
         .thenReturn(SshWinRmAwsInfrastructureOutcome.builder()
                         .connectorRef("awsconnector")
                         .hostConnectionType("PrivateIP")
@@ -474,7 +475,7 @@ public class InfrastructureTaskExecutableStepV2Test extends CategoryTest {
         .getSshInfraDelegateConfig(any(InfrastructureOutcome.class), any(Ambiance.class));
 
     mockInfra(azureInfra);
-    when(infrastructureOutcomeProvider.getOutcome(any(), any(), any(), any(), any(), any(), any()))
+    when(infrastructureOutcomeProvider.getOutcome(any(), any(), any(), any(), any(), any(), any(), anyMap()))
         .thenReturn(SshWinRmAzureInfrastructureOutcome.builder()
                         .connectorRef("azureconnector")
                         .subscriptionId("dev-subscription")

--- a/126-instance/src/main/java/io/harness/service/instancesyncperpetualtask/instancesyncperpetualtaskhandler/aws/AwsSshWinrmInstanceSyncPerpetualTaskHandler.java
+++ b/126-instance/src/main/java/io/harness/service/instancesyncperpetualtask/instancesyncperpetualtaskhandler/aws/AwsSshWinrmInstanceSyncPerpetualTaskHandler.java
@@ -143,7 +143,7 @@ public class AwsSshWinrmInstanceSyncPerpetualTaskHandler extends InstanceSyncPer
           .awsConnectorDTO(awsConnectorDTO)
           .region(awsInfrastructureOutcome.getRegion())
           .connectorEncryptionDataDetails(encryptedData)
-          .tags(sshEntityHelper.filterInfraTags(awsInfrastructureOutcome.getTags()))
+          .tags(sshEntityHelper.filterInfraTags(awsInfrastructureOutcome.getHostTags()))
           .build();
     } else if (secretSpecDTO instanceof WinRmCredentialsSpecDTO) {
       return AwsWinrmInfraDelegateConfig.winrmAwsBuilder()
@@ -151,7 +151,7 @@ public class AwsSshWinrmInstanceSyncPerpetualTaskHandler extends InstanceSyncPer
           .awsConnectorDTO(awsConnectorDTO)
           .connectorEncryptionDataDetails(encryptedData)
           .region(awsInfrastructureOutcome.getRegion())
-          .tags(sshEntityHelper.filterInfraTags(awsInfrastructureOutcome.getTags()))
+          .tags(sshEntityHelper.filterInfraTags(awsInfrastructureOutcome.getHostTags()))
           .build();
     }
     throw new InvalidArgumentsException(format("Invalid subclass %s provided for %s",

--- a/126-instance/src/main/java/io/harness/service/instancesyncperpetualtask/instancesyncperpetualtaskhandler/azure/AzureSshWinrmInstanceSyncPerpetualTaskHandler.java
+++ b/126-instance/src/main/java/io/harness/service/instancesyncperpetualtask/instancesyncperpetualtaskhandler/azure/AzureSshWinrmInstanceSyncPerpetualTaskHandler.java
@@ -156,7 +156,7 @@ public class AzureSshWinrmInstanceSyncPerpetualTaskHandler extends InstanceSyncP
           .connectorEncryptionDataDetails(encryptedData)
           .resourceGroup(azureInfrastructureOutcome.getResourceGroup())
           .subscriptionId(azureInfrastructureOutcome.getSubscriptionId())
-          .tags(sshEntityHelper.filterInfraTags(azureInfrastructureOutcome.getTags()))
+          .tags(sshEntityHelper.filterInfraTags(azureInfrastructureOutcome.getHostTags()))
           .hostConnectionType(azureInfrastructureOutcome.getHostConnectionType())
           .build();
     } else if (secretSpecDTO instanceof WinRmCredentialsSpecDTO) {
@@ -166,7 +166,7 @@ public class AzureSshWinrmInstanceSyncPerpetualTaskHandler extends InstanceSyncP
           .connectorEncryptionDataDetails(encryptedData)
           .resourceGroup(azureInfrastructureOutcome.getResourceGroup())
           .subscriptionId(azureInfrastructureOutcome.getSubscriptionId())
-          .tags(sshEntityHelper.filterInfraTags(azureInfrastructureOutcome.getTags()))
+          .tags(sshEntityHelper.filterInfraTags(azureInfrastructureOutcome.getHostTags()))
           .hostConnectionType(azureInfrastructureOutcome.getHostConnectionType())
           .build();
     }

--- a/126-instance/src/test/java/io/harness/service/instancesyncperpetualtask/instancesyncperpetualtaskhandler/aws/AwsSshWinrmInstanceSyncPerpetualTaskHandlerTest.java
+++ b/126-instance/src/test/java/io/harness/service/instancesyncperpetualtask/instancesyncperpetualtaskhandler/aws/AwsSshWinrmInstanceSyncPerpetualTaskHandlerTest.java
@@ -103,7 +103,7 @@ public class AwsSshWinrmInstanceSyncPerpetualTaskHandlerTest extends InstancesTe
                                                    .infrastructureKey(INFRASTRUCTURE_KEY)
                                                    .credentialsRef(CRED_REF)
                                                    .hostConnectionType(HostConnectionTypeKind.PRIVATE_IP)
-                                                   .tags(new HashMap<>())
+                                                   .hostTags(new HashMap<>())
                                                    .build();
     SecretSpec secretSpec = Mockito.mock(SecretSpec.class);
     doReturn(SSHKeySpecDTO.builder().port(PORT).build()).when(secretSpec).toDTO();

--- a/127-cd-nextgen-entities/src/main/java/io/harness/cdng/infra/beans/InfrastructureOutcomeAbstract.java
+++ b/127-cd-nextgen-entities/src/main/java/io/harness/cdng/infra/beans/InfrastructureOutcomeAbstract.java
@@ -10,6 +10,7 @@ package io.harness.cdng.infra.beans;
 import io.harness.cdng.infra.Connector;
 
 import io.swagger.annotations.ApiModelProperty;
+import java.util.Map;
 import lombok.Data;
 import lombok.Getter;
 
@@ -31,4 +32,6 @@ public abstract class InfrastructureOutcomeAbstract implements InfrastructureOut
   @ApiModelProperty(hidden = true) public Boolean skipInstances;
 
   private Connector connector;
+
+  Map<String, String> tags;
 }

--- a/127-cd-nextgen-entities/src/main/java/io/harness/cdng/infra/beans/SshWinRmAwsInfrastructureOutcome.java
+++ b/127-cd-nextgen-entities/src/main/java/io/harness/cdng/infra/beans/SshWinRmAwsInfrastructureOutcome.java
@@ -30,7 +30,7 @@ public class SshWinRmAwsInfrastructureOutcome extends InfrastructureOutcomeAbstr
   private String connectorRef;
   private String credentialsRef;
   private String region;
-  Map<String, String> tags;
+  Map<String, String> hostTags;
   private String hostConnectionType;
 
   @VariableExpression(skipVariableExpression = true) private EnvironmentOutcome environment;

--- a/127-cd-nextgen-entities/src/main/java/io/harness/cdng/infra/beans/SshWinRmAzureInfrastructureOutcome.java
+++ b/127-cd-nextgen-entities/src/main/java/io/harness/cdng/infra/beans/SshWinRmAzureInfrastructureOutcome.java
@@ -31,7 +31,7 @@ public class SshWinRmAzureInfrastructureOutcome extends InfrastructureOutcomeAbs
   String subscriptionId;
   String resourceGroup;
   String credentialsRef;
-  Map<String, String> tags;
+  Map<String, String> hostTags;
   String hostConnectionType;
 
   @VariableExpression(skipVariableExpression = true) EnvironmentOutcome environment;

--- a/127-cd-nextgen-entities/src/main/java/io/harness/cdng/ssh/SshEntityHelper.java
+++ b/127-cd-nextgen-entities/src/main/java/io/harness/cdng/ssh/SshEntityHelper.java
@@ -150,7 +150,7 @@ public class SshEntityHelper {
             .encryptionDataDetails(sshKeySpecDTOHelper.getSSHKeyEncryptionDetails(sshKeySpecDto, ngAccess))
             .subscriptionId(azureInfrastructureOutcome.getSubscriptionId())
             .resourceGroup(azureInfrastructureOutcome.getResourceGroup())
-            .tags(filterInfraTags(azureInfrastructureOutcome.getTags()))
+            .tags(filterInfraTags(azureInfrastructureOutcome.getHostTags()))
             .hostConnectionType(azureInfrastructureOutcome.getHostConnectionType())
             .build();
       case SSH_WINRM_AWS:
@@ -168,7 +168,7 @@ public class SshEntityHelper {
             .sshKeySpecDto(sshKeySpecDto)
             .encryptionDataDetails(sshKeySpecDTOHelper.getSSHKeyEncryptionDetails(sshKeySpecDto, ngAccess))
             .region(awsInfrastructureOutcome.getRegion())
-            .tags(filterInfraTags(awsInfrastructureOutcome.getTags()))
+            .tags(filterInfraTags(awsInfrastructureOutcome.getHostTags()))
             .build();
 
       case CUSTOM_DEPLOYMENT:
@@ -217,7 +217,7 @@ public class SshEntityHelper {
             .encryptionDataDetails(winRmCredentialsSpecDTOHelper.getWinRmEncryptionDetails(winRmCredentials, ngAccess))
             .subscriptionId(azureInfrastructureOutcome.getSubscriptionId())
             .resourceGroup(azureInfrastructureOutcome.getResourceGroup())
-            .tags(filterInfraTags(azureInfrastructureOutcome.getTags()))
+            .tags(filterInfraTags(azureInfrastructureOutcome.getHostTags()))
             .hostConnectionType(azureInfrastructureOutcome.getHostConnectionType())
             .build();
       case SSH_WINRM_AWS:
@@ -235,7 +235,7 @@ public class SshEntityHelper {
             .winRmCredentials(winRmCredentials)
             .encryptionDataDetails(winRmCredentialsSpecDTOHelper.getWinRmEncryptionDetails(winRmCredentials, ngAccess))
             .region(awsInfrastructureOutcome.getRegion())
-            .tags(filterInfraTags(awsInfrastructureOutcome.getTags()))
+            .tags(filterInfraTags(awsInfrastructureOutcome.getHostTags()))
             .build();
       default:
         throw new UnsupportedOperationException(

--- a/127-cd-nextgen-entities/src/test/java/io/harness/cdng/ssh/SshEntityHelperTest.java
+++ b/127-cd-nextgen-entities/src/test/java/io/harness/cdng/ssh/SshEntityHelperTest.java
@@ -447,7 +447,7 @@ public class SshEntityHelperTest extends CategoryTest {
                                                                  .credentialsRef("sshKeyRef")
                                                                  .subscriptionId("subscriptionId")
                                                                  .resourceGroup("resourceGroup")
-                                                                 .tags(ImmutableMap.of("ENV", "Dev"))
+                                                                 .hostTags(ImmutableMap.of("ENV", "Dev"))
                                                                  .hostConnectionType("Hostname")
                                                                  .build();
 
@@ -478,7 +478,7 @@ public class SshEntityHelperTest extends CategoryTest {
                                                              .credentialsRef("sshKeyRef")
                                                              .region("regionId")
                                                              .hostConnectionType("PrivateIP")
-                                                             .tags(Collections.singletonMap("testTag", "test"))
+                                                             .hostTags(Collections.singletonMap("testTag", "test"))
                                                              .build();
 
     mockSecretKey();
@@ -582,7 +582,7 @@ public class SshEntityHelperTest extends CategoryTest {
                                                                  .credentialsRef("winrmCredentialsRef")
                                                                  .subscriptionId("subscriptionId")
                                                                  .resourceGroup("resourceGroup")
-                                                                 .tags(ImmutableMap.of("ENV", "Dev"))
+                                                                 .hostTags(ImmutableMap.of("ENV", "Dev"))
                                                                  .hostConnectionType("PublicIP")
                                                                  .build();
 
@@ -622,7 +622,7 @@ public class SshEntityHelperTest extends CategoryTest {
                                                              .credentialsRef("winrmCredentialsRef")
                                                              .region("regionId")
                                                              .hostConnectionType("PublicIP")
-                                                             .tags(Collections.singletonMap("testTag", "test"))
+                                                             .hostTags(Collections.singletonMap("testTag", "test"))
                                                              .build();
 
     Call<ResponseDTO<SecretResponseWrapper>> getSecretCall = mock(Call.class);


### PR DESCRIPTION
* feat: [CDS-68462]: Renamed SSH/WinRM Azure and AWS infra outcome tags to hostTags

* feat: [CDC-59370]: add infra tags to infrastructure outcome

* add UT

* use tags in async task

* remove import unused

* fix existing tests

* fix format

* use merged tags to add to outcome

---------

Co-authored-by: Ivan Mijailovic <ivan.mijailovic@harness.io>