### PR TITLE
fix: [SRM-14734]: Handle outbox events for Downtime and remove Contributed error budget burned from least performant Composite SLO consumption (#47647)

### DIFF
--- a/srm-service/modules/cv-nextgen-service/service/src/main/java/io/harness/cvng/CVServiceModule.java
+++ b/srm-service/modules/cv-nextgen-service/service/src/main/java/io/harness/cvng/CVServiceModule.java
@@ -345,6 +345,7 @@ import io.harness.cvng.notification.transformer.PagerDutyNotificationMethodTrans
 import io.harness.cvng.notification.transformer.SLONotificationRuleConditionTransformer;
 import io.harness.cvng.notification.transformer.SlackNotificationMethodTransformer;
 import io.harness.cvng.outbox.CVServiceOutboxEventHandler;
+import io.harness.cvng.outbox.DowntimeOutboxEventHandler;
 import io.harness.cvng.outbox.MonitoredServiceOutboxEventHandler;
 import io.harness.cvng.outbox.ServiceLevelObjectiveOutboxEventHandler;
 import io.harness.cvng.resources.VerifyStepResource;
@@ -1296,6 +1297,7 @@ public class CVServiceModule extends AbstractModule {
         .to(MonitoredServiceOutboxEventHandler.class);
     outboxEventHandlerMap.addBinding(ResourceTypeConstants.SERVICE_LEVEL_OBJECTIVE)
         .to(ServiceLevelObjectiveOutboxEventHandler.class);
+    outboxEventHandlerMap.addBinding(ResourceTypeConstants.DOWNTIME).to(DowntimeOutboxEventHandler.class);
     bind(OutboxEventHandler.class).to(CVServiceOutboxEventHandler.class);
     bindRetryOnExceptionInterceptor();
     install(EnforcementClientModule.getInstance(verificationConfiguration.getNgManagerClientConfig(),

--- a/srm-service/modules/cv-nextgen-service/service/src/main/java/io/harness/cvng/outbox/DowntimeOutboxEventHandler.java
+++ b/srm-service/modules/cv-nextgen-service/service/src/main/java/io/harness/cvng/outbox/DowntimeOutboxEventHandler.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.cvng.outbox;
+
+import static io.harness.ng.core.utils.NGYamlUtils.getYamlString;
+
+import io.harness.ModuleType;
+import io.harness.audit.Action;
+import io.harness.audit.beans.AuditEntry;
+import io.harness.audit.beans.ResourceDTO;
+import io.harness.audit.beans.ResourceScopeDTO;
+import io.harness.audit.client.api.AuditClientService;
+import io.harness.context.GlobalContext;
+import io.harness.cvng.events.downtime.DowntimeCreateEvent;
+import io.harness.cvng.events.downtime.DowntimeDeleteEvent;
+import io.harness.cvng.events.downtime.DowntimeUpdateEvent;
+import io.harness.outbox.OutboxEvent;
+import io.harness.outbox.api.OutboxEventHandler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
+import io.serializer.HObjectMapper;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class DowntimeOutboxEventHandler implements OutboxEventHandler {
+  private final AuditClientService auditClientService;
+  private final ObjectMapper objectMapper;
+
+  @Inject
+  DowntimeOutboxEventHandler(AuditClientService auditClientService) {
+    this.auditClientService = auditClientService;
+    this.objectMapper = HObjectMapper.NG_DEFAULT_OBJECT_MAPPER;
+  }
+
+  @Override
+  public boolean handle(OutboxEvent outboxEvent) {
+    log.info("Outbox event handler: {}", outboxEvent);
+    GlobalContext globalContext = outboxEvent.getGlobalContext();
+    try {
+      switch (outboxEvent.getEventType()) {
+        case "DowntimeCreateEvent":
+          return handleDowntimeCreateEvent(outboxEvent, globalContext);
+        case "DowntimeUpdateEvent":
+          return handleDowntimeUpdateEvent(outboxEvent, globalContext);
+        case "DowntimeDeleteEvent":
+          return handleDowntimeDeleteEvent(outboxEvent, globalContext);
+        default:
+          return false;
+      }
+    } catch (IOException exception) {
+      return false;
+    }
+  }
+
+  private boolean handleDowntimeCreateEvent(OutboxEvent outboxEvent, GlobalContext globalContext) throws IOException {
+    DowntimeCreateEvent downtimeCreateEvent =
+        objectMapper.readValue(outboxEvent.getEventData(), DowntimeCreateEvent.class);
+    AuditEntry auditEntry = AuditEntry.builder()
+                                .action(Action.CREATE)
+                                .module(ModuleType.CV)
+                                .newYaml(getYamlString(downtimeCreateEvent.getDowntimeDTO()))
+                                .timestamp(outboxEvent.getCreatedAt())
+                                .resource(ResourceDTO.fromResource(outboxEvent.getResource()))
+                                .resourceScope(ResourceScopeDTO.fromResourceScope(outboxEvent.getResourceScope()))
+                                .insertId(outboxEvent.getId())
+                                .build();
+    return auditClientService.publishAudit(auditEntry, globalContext);
+  }
+
+  private boolean handleDowntimeUpdateEvent(OutboxEvent outboxEvent, GlobalContext globalContext) throws IOException {
+    DowntimeUpdateEvent downtimeUpdateEvent =
+        objectMapper.readValue(outboxEvent.getEventData(), DowntimeUpdateEvent.class);
+    AuditEntry auditEntry = AuditEntry.builder()
+                                .action(Action.UPDATE)
+                                .module(ModuleType.CV)
+                                .oldYaml(getYamlString(downtimeUpdateEvent.getOldDowntimeDTO()))
+                                .newYaml(getYamlString(downtimeUpdateEvent.getNewDowntimeDTO()))
+                                .timestamp(outboxEvent.getCreatedAt())
+                                .resource(ResourceDTO.fromResource(outboxEvent.getResource()))
+                                .resourceScope(ResourceScopeDTO.fromResourceScope(outboxEvent.getResourceScope()))
+                                .insertId(outboxEvent.getId())
+                                .build();
+    return auditClientService.publishAudit(auditEntry, globalContext);
+  }
+
+  private boolean handleDowntimeDeleteEvent(OutboxEvent outboxEvent, GlobalContext globalContext) throws IOException {
+    DowntimeDeleteEvent downtimeDeleteEvent =
+        objectMapper.readValue(outboxEvent.getEventData(), DowntimeDeleteEvent.class);
+    AuditEntry auditEntry = AuditEntry.builder()
+                                .action(Action.DELETE)
+                                .module(ModuleType.CV)
+                                .oldYaml(getYamlString(downtimeDeleteEvent.getDowntimeDTO()))
+                                .timestamp(outboxEvent.getCreatedAt())
+                                .resource(ResourceDTO.fromResource(outboxEvent.getResource()))
+                                .resourceScope(ResourceScopeDTO.fromResourceScope(outboxEvent.getResourceScope()))
+                                .insertId(outboxEvent.getId())
+                                .build();
+    return auditClientService.publishAudit(auditEntry, globalContext);
+  }
+}

--- a/srm-service/modules/cv-nextgen-service/service/src/main/java/io/harness/cvng/servicelevelobjective/beans/SLOConsumptionBreakdown.java
+++ b/srm-service/modules/cv-nextgen-service/service/src/main/java/io/harness/cvng/servicelevelobjective/beans/SLOConsumptionBreakdown.java
@@ -10,11 +10,11 @@ package io.harness.cvng.servicelevelobjective.beans;
 import io.harness.cvng.core.beans.params.ProjectParams;
 
 import javax.validation.constraints.NotNull;
-import lombok.Builder;
-import lombok.Value;
+import lombok.Data;
+import lombok.experimental.SuperBuilder;
 
-@Value
-@Builder
+@Data
+@SuperBuilder
 public class SLOConsumptionBreakdown {
   @NotNull String sloIdentifier;
   @NotNull String sloName;
@@ -26,7 +26,7 @@ public class SLOConsumptionBreakdown {
   @NotNull double sloTargetPercentage;
   @NotNull double sliStatusPercentage;
   @NotNull long errorBudgetBurned;
-  @NotNull int contributedErrorBudgetBurned;
+  Integer contributedErrorBudgetBurned;
   @NotNull ProjectParams projectParams;
   String orgName;
   String projectName;

--- a/srm-service/modules/cv-nextgen-service/service/src/main/java/io/harness/cvng/servicelevelobjective/services/impl/SLODashboardServiceImpl.java
+++ b/srm-service/modules/cv-nextgen-service/service/src/main/java/io/harness/cvng/servicelevelobjective/services/impl/SLODashboardServiceImpl.java
@@ -25,6 +25,7 @@ import io.harness.cvng.downtime.entities.EntityUnavailabilityStatuses;
 import io.harness.cvng.downtime.services.api.DowntimeService;
 import io.harness.cvng.downtime.services.api.EntityUnavailabilityStatusesService;
 import io.harness.cvng.servicelevelobjective.SLORiskCountResponse;
+import io.harness.cvng.servicelevelobjective.beans.CompositeSLOFormulaType;
 import io.harness.cvng.servicelevelobjective.beans.MSDropdownResponse;
 import io.harness.cvng.servicelevelobjective.beans.MonitoredServiceDetail;
 import io.harness.cvng.servicelevelobjective.beans.SLIEvaluationType;
@@ -384,23 +385,28 @@ public class SLODashboardServiceImpl implements SLODashboardService {
     String projectName = getProjectName(projectParams.getAccountIdentifier(), simpleSLOProjectParams.getOrgIdentifier(),
         simpleSLOProjectParams.getProjectIdentifier());
     String orgName = getOrgName(projectParams.getAccountIdentifier(), simpleSLOProjectParams.getOrgIdentifier());
-    return SLOConsumptionBreakdown.builder()
-        .sloIdentifier(sloDetail.getSloIdentifier())
-        .sloName(sloDetail.getName())
-        .monitoredServiceIdentifier(sloDetail.getMonitoredServiceIdentifier())
-        .serviceName(sloDetail.getServiceName())
-        .environmentIdentifier(sloDetail.getEnvironmentIdentifier())
-        .sliType(sloDetail.getSliType())
-        .weightagePercentage(weightPercentage)
-        .sloTargetPercentage(sloDetail.getSloTargetPercentage())
-        .sliStatusPercentage(sloGraphData.getSliStatusPercentage())
-        .errorBudgetBurned(sloGraphData.getErrorBudgetBurned())
-        .contributedErrorBudgetBurned((int) ((weightPercentage / 100) * sloGraphData.getErrorBudgetBurned()))
-        .projectParams(simpleSLOProjectParams)
-        .projectName(projectName)
-        .orgName(orgName)
-        .sloError(sloDetail.getSloError())
-        .build();
+    SLOConsumptionBreakdown sloConsumptionBreakdown =
+        SLOConsumptionBreakdown.builder()
+            .sloIdentifier(sloDetail.getSloIdentifier())
+            .sloName(sloDetail.getName())
+            .monitoredServiceIdentifier(sloDetail.getMonitoredServiceIdentifier())
+            .serviceName(sloDetail.getServiceName())
+            .environmentIdentifier(sloDetail.getEnvironmentIdentifier())
+            .sliType(sloDetail.getSliType())
+            .weightagePercentage(weightPercentage)
+            .sloTargetPercentage(sloDetail.getSloTargetPercentage())
+            .sliStatusPercentage(sloGraphData.getSliStatusPercentage())
+            .errorBudgetBurned(sloGraphData.getErrorBudgetBurned())
+            .projectParams(simpleSLOProjectParams)
+            .projectName(projectName)
+            .orgName(orgName)
+            .sloError(sloDetail.getSloError())
+            .build();
+    if (compositeServiceLevelObjective.getCompositeSLOFormulaType().equals(CompositeSLOFormulaType.WEIGHTED_AVERAGE)) {
+      sloConsumptionBreakdown.setContributedErrorBudgetBurned(
+          (int) ((weightPercentage / 100) * sloGraphData.getErrorBudgetBurned()));
+    }
+    return sloConsumptionBreakdown;
   }
 
   @Override

--- a/srm-service/modules/cv-nextgen-service/service/src/test/java/io/harness/cvng/outbox/DowntimeOutboxEventHandlerTest.java
+++ b/srm-service/modules/cv-nextgen-service/service/src/test/java/io/harness/cvng/outbox/DowntimeOutboxEventHandlerTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.cvng.outbox;
+
+import static io.harness.rule.OwnerRule.VARSHA_LALWANI;
+
+import io.harness.CvNextGenTestBase;
+import io.harness.audit.ResourceTypeConstants;
+import io.harness.category.element.UnitTests;
+import io.harness.cvng.BuilderFactory;
+import io.harness.cvng.core.beans.monitoredService.MonitoredServiceDTO;
+import io.harness.cvng.core.beans.params.ProjectParams;
+import io.harness.cvng.core.services.api.monitoredService.MonitoredServiceService;
+import io.harness.cvng.downtime.beans.DowntimeDTO;
+import io.harness.cvng.downtime.services.api.DowntimeService;
+import io.harness.cvng.events.downtime.DowntimeCreateEvent;
+import io.harness.cvng.events.downtime.DowntimeDeleteEvent;
+import io.harness.cvng.events.downtime.DowntimeUpdateEvent;
+import io.harness.cvng.servicelevelobjective.beans.ServiceLevelObjectiveV2DTO;
+import io.harness.cvng.servicelevelobjective.services.api.ServiceLevelObjectiveV2Service;
+import io.harness.ng.core.ProjectScope;
+import io.harness.ng.core.Resource;
+import io.harness.ng.core.ResourceScope;
+import io.harness.outbox.OutboxEvent;
+import io.harness.rule.Owner;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
+import io.serializer.HObjectMapper;
+import javax.annotation.Nullable;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+public class DowntimeOutboxEventHandlerTest extends CvNextGenTestBase {
+  @Inject MonitoredServiceService monitoredServiceService;
+
+  @Inject ServiceLevelObjectiveV2Service serviceLevelObjectiveV2Service;
+
+  @Inject DowntimeService downtimeService;
+
+  @Inject CVServiceOutboxEventHandler cvServiceOutboxEventHandler;
+
+  private BuilderFactory builderFactory;
+  ServiceLevelObjectiveV2DTO sloDTO;
+
+  @Before
+  public void setup() throws IllegalAccessException {
+    builderFactory = BuilderFactory.getDefault();
+    ProjectParams projectParams = builderFactory.getProjectParams();
+    sloDTO = builderFactory.getSimpleServiceLevelObjectiveV2DTOBuilder().build();
+    createMonitoredService();
+    serviceLevelObjectiveV2Service.create(projectParams, sloDTO);
+  }
+
+  @Test
+  @Owner(developers = VARSHA_LALWANI)
+  @Category(UnitTests.class)
+  public void testHandle_DowntimeCreateEvent() throws JsonProcessingException {
+    @Nullable ObjectMapper objectMapper;
+    objectMapper = HObjectMapper.NG_DEFAULT_OBJECT_MAPPER;
+    DowntimeDTO recurringDowntimeDTO = builderFactory.getRecurringDowntimeDTO();
+    downtimeService.create(builderFactory.getProjectParams(), recurringDowntimeDTO);
+
+    DowntimeCreateEvent downtimeCreateEvent = DowntimeCreateEvent.builder()
+                                                  .resourceName(recurringDowntimeDTO.getName())
+                                                  .downtimeIdentifier(recurringDowntimeDTO.getIdentifier())
+                                                  .accountIdentifier(recurringDowntimeDTO.getIdentifier())
+                                                  .orgIdentifier(recurringDowntimeDTO.getOrgIdentifier())
+                                                  .projectIdentifier(recurringDowntimeDTO.getProjectIdentifier())
+                                                  .downtimeDTO(recurringDowntimeDTO)
+                                                  .build();
+    String createEventString = objectMapper.writeValueAsString(downtimeCreateEvent);
+    ResourceScope resourceScope = new ProjectScope(downtimeCreateEvent.getDowntimeIdentifier(),
+        downtimeCreateEvent.getOrgIdentifier(), downtimeCreateEvent.getProjectIdentifier());
+    OutboxEvent outboxEvent = OutboxEvent.builder()
+                                  .eventType("DowntimeCreateEvent")
+                                  .resourceScope(resourceScope)
+                                  .eventData(createEventString)
+                                  .createdAt(System.currentTimeMillis())
+                                  .resource(Resource.builder().type(ResourceTypeConstants.DOWNTIME).build())
+                                  .build();
+    Boolean returnValue = cvServiceOutboxEventHandler.handle(outboxEvent);
+    Assertions.assertThat(returnValue).isTrue();
+  }
+
+  @Test
+  @Owner(developers = VARSHA_LALWANI)
+  @Category(UnitTests.class)
+  public void testHandle_DowntimeUpdateEvent() throws JsonProcessingException {
+    @Nullable ObjectMapper objectMapper;
+    objectMapper = HObjectMapper.NG_DEFAULT_OBJECT_MAPPER;
+    DowntimeDTO recurringDowntimeDTO = builderFactory.getRecurringDowntimeDTO();
+    downtimeService.create(builderFactory.getProjectParams(), recurringDowntimeDTO);
+
+    DowntimeUpdateEvent downtimeUpdateEvent = DowntimeUpdateEvent.builder()
+                                                  .resourceName(recurringDowntimeDTO.getName())
+                                                  .downtimeIdentifier(recurringDowntimeDTO.getIdentifier())
+                                                  .accountIdentifier(recurringDowntimeDTO.getIdentifier())
+                                                  .orgIdentifier(recurringDowntimeDTO.getOrgIdentifier())
+                                                  .projectIdentifier(recurringDowntimeDTO.getProjectIdentifier())
+                                                  .oldDowntimeDTO(recurringDowntimeDTO)
+                                                  .newDowntimeDTO(recurringDowntimeDTO)
+                                                  .build();
+    String createEventString = objectMapper.writeValueAsString(downtimeUpdateEvent);
+    ResourceScope resourceScope = new ProjectScope(downtimeUpdateEvent.getDowntimeIdentifier(),
+        downtimeUpdateEvent.getOrgIdentifier(), downtimeUpdateEvent.getProjectIdentifier());
+    OutboxEvent outboxEvent = OutboxEvent.builder()
+                                  .eventType("DowntimeUpdateEvent")
+                                  .resourceScope(resourceScope)
+                                  .eventData(createEventString)
+                                  .createdAt(System.currentTimeMillis())
+                                  .resource(Resource.builder().type(ResourceTypeConstants.DOWNTIME).build())
+                                  .build();
+    Boolean returnValue = cvServiceOutboxEventHandler.handle(outboxEvent);
+    Assertions.assertThat(returnValue).isTrue();
+  }
+
+  @Test
+  @Owner(developers = VARSHA_LALWANI)
+  @Category(UnitTests.class)
+  public void testHandle_DowntimeDeleteEvent() throws JsonProcessingException {
+    @Nullable ObjectMapper objectMapper;
+    objectMapper = HObjectMapper.NG_DEFAULT_OBJECT_MAPPER;
+    DowntimeDTO recurringDowntimeDTO = builderFactory.getRecurringDowntimeDTO();
+    downtimeService.create(builderFactory.getProjectParams(), recurringDowntimeDTO);
+
+    DowntimeDeleteEvent downtimeDeleteEvent = DowntimeDeleteEvent.builder()
+                                                  .resourceName(recurringDowntimeDTO.getName())
+                                                  .downtimeIdentifier(recurringDowntimeDTO.getIdentifier())
+                                                  .accountIdentifier(recurringDowntimeDTO.getIdentifier())
+                                                  .orgIdentifier(recurringDowntimeDTO.getOrgIdentifier())
+                                                  .projectIdentifier(recurringDowntimeDTO.getProjectIdentifier())
+                                                  .downtimeDTO(recurringDowntimeDTO)
+                                                  .build();
+    String createEventString = objectMapper.writeValueAsString(downtimeDeleteEvent);
+    ResourceScope resourceScope = new ProjectScope(downtimeDeleteEvent.getDowntimeIdentifier(),
+        downtimeDeleteEvent.getOrgIdentifier(), downtimeDeleteEvent.getProjectIdentifier());
+    OutboxEvent outboxEvent = OutboxEvent.builder()
+                                  .eventType("DowntimeDeleteEvent")
+                                  .resourceScope(resourceScope)
+                                  .eventData(createEventString)
+                                  .createdAt(System.currentTimeMillis())
+                                  .resource(Resource.builder().type(ResourceTypeConstants.DOWNTIME).build())
+                                  .build();
+    Boolean returnValue = cvServiceOutboxEventHandler.handle(outboxEvent);
+    Assertions.assertThat(returnValue).isTrue();
+  }
+
+  private void createMonitoredService() {
+    MonitoredServiceDTO monitoredServiceDTO =
+        builderFactory.monitoredServiceDTOBuilder()
+            .identifier(builderFactory.getContext().getMonitoredServiceIdentifier())
+            .build();
+    monitoredServiceDTO.setSources(MonitoredServiceDTO.Sources.builder().build());
+    monitoredServiceService.create(builderFactory.getContext().getAccountId(), monitoredServiceDTO);
+  }
+}


### PR DESCRIPTION
* fix: [SRM-14734]: Handle outbox events for Downtime

* fix: [SRM-14733]: Remove contributed error budget burned for least performance composite SLO