### PR TITLE
fix: [CDS-58702]: Fix and refactor API steady state uninterruptible socket read (#47398)

### DIFF
--- a/930-delegate-tasks/src/main/java/io/harness/delegate/task/k8s/client/K8sClientHelper.java
+++ b/930-delegate-tasks/src/main/java/io/harness/delegate/task/k8s/client/K8sClientHelper.java
@@ -11,6 +11,7 @@ import static java.util.stream.Collectors.toSet;
 
 import io.harness.delegate.task.k8s.ContainerDeploymentDelegateBaseHelper;
 import io.harness.delegate.task.k8s.K8sInfraDelegateConfig;
+import io.harness.k8s.KubernetesApiRetryUtils;
 import io.harness.k8s.KubernetesHelperService;
 import io.harness.k8s.kubectl.Kubectl;
 import io.harness.k8s.model.K8sDelegateTaskParams;
@@ -23,6 +24,7 @@ import io.harness.logging.LogCallback;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import io.github.resilience4j.retry.Retry;
 import io.kubernetes.client.openapi.ApiClient;
 import java.util.List;
 import java.util.Set;
@@ -37,6 +39,8 @@ public class K8sClientHelper {
   private static final String MAX_RESOURCE_NAME_LENGTH = "${MAX_RESOURCE_NAME_LENGTH}";
   private static final String EVENT_INFO_FORMAT = "%-7s: %-" + MAX_RESOURCE_NAME_LENGTH + "s   %s";
   private static final String WATCH_STATUS_FORMAT = "%n%-7s: %-" + MAX_RESOURCE_NAME_LENGTH + "s   %s";
+
+  private final Retry watchRetry = KubernetesApiRetryUtils.buildRetryAndRegisterListeners(this.getClass().getName());
 
   K8sEventWatchDTO createEventWatchDTO(K8sSteadyStateDTO steadyStateDTO, ApiClient apiClient) {
     final String eventInfoFormat = fetchEventInfoFormat(steadyStateDTO.getResourceIds(), EVENT_INFO_FORMAT);
@@ -68,6 +72,7 @@ public class K8sClientHelper {
     final String statusFormat = fetchEventInfoFormat(steadyStateDTO.getResourceIds(), WATCH_STATUS_FORMAT);
     return K8sStatusWatchDTO.builder()
         .apiClient(apiClient)
+        .retry(watchRetry)
         .k8sDelegateTaskParams(steadyStateDTO.getK8sDelegateTaskParams())
         .isErrorFrameworkEnabled(steadyStateDTO.isErrorFrameworkEnabled())
         .statusFormat(statusFormat)

--- a/960-api-services/src/main/java/io/harness/k8s/KubernetesApiRetryUtils.java
+++ b/960-api-services/src/main/java/io/harness/k8s/KubernetesApiRetryUtils.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+package io.harness.k8s;
+
+import io.harness.annotations.dev.HarnessTeam;
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.retry.RetryHelper;
+
+import io.github.resilience4j.retry.Retry;
+import java.io.EOFException;
+import java.net.ConnectException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.TimeoutException;
+import lombok.experimental.UtilityClass;
+import okhttp3.internal.http2.ConnectionShutdownException;
+import okhttp3.internal.http2.StreamResetException;
+
+@UtilityClass
+@OwnedBy(HarnessTeam.CDP)
+public class KubernetesApiRetryUtils {
+  public Retry buildRetryAndRegisterListeners(String name) {
+    final Retry exponentialRetry = RetryHelper.getExponentialRetry(name,
+        new Class[] {ConnectException.class, TimeoutException.class, ConnectionShutdownException.class,
+            StreamResetException.class, SocketException.class, EOFException.class, SocketTimeoutException.class});
+    RetryHelper.registerEventListeners(exponentialRetry);
+    return exponentialRetry;
+  }
+}

--- a/960-api-services/src/main/java/io/harness/k8s/steadystate/model/K8sStatusWatchDTO.java
+++ b/960-api-services/src/main/java/io/harness/k8s/steadystate/model/K8sStatusWatchDTO.java
@@ -13,6 +13,7 @@ import io.harness.annotations.dev.OwnedBy;
 import io.harness.k8s.kubectl.Kubectl;
 import io.harness.k8s.model.K8sDelegateTaskParams;
 
+import io.github.resilience4j.retry.Retry;
 import io.kubernetes.client.openapi.ApiClient;
 import lombok.Builder;
 import lombok.Data;
@@ -22,6 +23,7 @@ import lombok.Data;
 @OwnedBy(CDP)
 public class K8sStatusWatchDTO {
   ApiClient apiClient;
+  Retry retry;
   Kubectl client;
   K8sDelegateTaskParams k8sDelegateTaskParams;
   boolean isErrorFrameworkEnabled;

--- a/960-api-services/src/main/java/io/harness/k8s/steadystate/watcher/client/BUILD.bazel
+++ b/960-api-services/src/main/java/io/harness/k8s/steadystate/watcher/client/BUILD.bazel
@@ -12,10 +12,12 @@ java_library(
     visibility = ["//visibility:public"],
     deps = [
         "//:lombok",
-        "//960-api-services/src/main/java/io/harness/k8s/kubectl:module",
-        "//970-api-services-beans:module",
+        "//960-api-services/src/main/java/io/harness/exception/sanitizer:module",
+        "//980-commons/src/main/java/io/harness/exception:module",
+        "//980-commons/src/main/java/io/harness/supplier:module",
         "//999-annotations/src/main/java/io/harness/annotations/dev:module",
         "@maven//:io_github_resilience4j_resilience4j_retry",
+        "@maven//:io_kubernetes_client_java",
         "@maven//:io_kubernetes_client_java_api",
     ],
 )

--- a/960-api-services/src/main/java/io/harness/k8s/steadystate/watcher/client/K8sBlockingWatchClient.java
+++ b/960-api-services/src/main/java/io/harness/k8s/steadystate/watcher/client/K8sBlockingWatchClient.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.k8s.steadystate.watcher.client;
+
+import static io.harness.annotations.dev.HarnessTeam.CDP;
+
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.exception.ExceptionUtils;
+import io.harness.exception.sanitizer.ExceptionMessageSanitizer;
+import io.harness.supplier.ThrowingSupplier;
+
+import io.github.resilience4j.retry.Retry;
+import io.kubernetes.client.common.KubernetesObject;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.util.Watch;
+import io.vavr.CheckedFunction0;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.Call;
+
+@Slf4j
+@OwnedBy(CDP)
+public class K8sBlockingWatchClient implements K8sWatchClient {
+  private final ExecutorService executor;
+
+  private final ApiClient apiClient;
+  private final Retry retryConfig;
+
+  K8sBlockingWatchClient(ApiClient apiClient) {
+    this.apiClient = apiClient;
+    this.retryConfig = null;
+    this.executor = Executors.newSingleThreadExecutor();
+  }
+
+  K8sBlockingWatchClient(ApiClient apiClient, Retry retryConfig) {
+    this.apiClient = apiClient;
+    this.retryConfig = retryConfig;
+    this.executor = Executors.newSingleThreadExecutor();
+  }
+
+  K8sBlockingWatchClient(ApiClient apiClient, Retry retryConfig, ExecutorService executor) {
+    this.apiClient = apiClient;
+    this.retryConfig = retryConfig;
+    this.executor = Objects.requireNonNullElseGet(executor, Executors::newSingleThreadExecutor);
+  }
+
+  @Override
+  public <T extends KubernetesObject> boolean waitOnCondition(
+      Type type, ThrowingSupplier<Call> callSupplier, K8sEventPredicate<T> condition) throws Exception {
+    Future<Boolean> future = null;
+    try {
+      // Due to an issue in the JDK socket read native method can prevent the current running request thread
+      // to be interrupted. To prevent hanging current task thread we're running the watch request in a different
+      // thread and if the current thread, even if the request running thread is unresponding to interrupt it
+      // will not block the task thread
+      future = executor.submit(() -> waitInternal(type, callSupplier, condition));
+      return future.get();
+    } catch (InterruptedException e) {
+      future.cancel(true);
+      throw e;
+    } catch (RejectedExecutionException e) {
+      // Even if we can't make this call in a different thread we can still try to execute request in curent thread
+      log.error("Failed to schedule a new task execution, fallback to default behavior", e);
+      return waitInternal(type, callSupplier, condition);
+    }
+  }
+
+  private <T extends KubernetesObject> boolean waitInternal(
+      Type type, ThrowingSupplier<Call> callSupplier, K8sEventPredicate<T> condition) throws Exception {
+    try {
+      if (retryConfig == null) {
+        return executeWait(type, callSupplier, condition);
+      }
+
+      CheckedFunction0<Boolean> retrySupplier =
+          Retry.decorateCheckedSupplier(retryConfig, () -> executeWait(type, callSupplier, condition));
+      return retrySupplier.apply();
+    } catch (Exception e) {
+      throw e;
+    } catch (Throwable t) {
+      // Callable from java function library interface don't handle throwable
+      throw new RuntimeException("Failed to watch workload", t);
+    }
+  }
+
+  private <T extends KubernetesObject> boolean executeWait(
+      Type type, ThrowingSupplier<Call> callSupplier, K8sEventPredicate<T> condition) throws Throwable {
+    while (!Thread.currentThread().isInterrupted()) {
+      try (Watch<T> watch = Watch.createWatch(apiClient, callSupplier.get(), type)) {
+        for (Watch.Response<T> event : watch) {
+          if (condition.test(event)) {
+            return true;
+          }
+        }
+      } catch (IOException e) {
+        IOException ex = ExceptionMessageSanitizer.sanitizeException(e);
+        String errorMessage = "Failed to close Kubernetes watch." + ExceptionUtils.getMessage(ex);
+        log.error(errorMessage, ex);
+        return false;
+      }
+    }
+
+    return false;
+  }
+}

--- a/960-api-services/src/main/java/io/harness/k8s/steadystate/watcher/client/K8sEventPredicate.java
+++ b/960-api-services/src/main/java/io/harness/k8s/steadystate/watcher/client/K8sEventPredicate.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.k8s.steadystate.watcher.client;
+
+import static io.harness.annotations.dev.HarnessTeam.CDP;
+
+import io.harness.annotations.dev.OwnedBy;
+
+import io.kubernetes.client.common.KubernetesObject;
+import io.kubernetes.client.util.Watch;
+
+@OwnedBy(CDP)
+public interface K8sEventPredicate<T extends KubernetesObject> {
+  boolean test(Watch.Response<T> response) throws Throwable;
+}

--- a/960-api-services/src/main/java/io/harness/k8s/steadystate/watcher/client/K8sWatchClient.java
+++ b/960-api-services/src/main/java/io/harness/k8s/steadystate/watcher/client/K8sWatchClient.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.k8s.steadystate.watcher.client;
+
+import io.harness.annotations.dev.HarnessTeam;
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.supplier.ThrowingSupplier;
+
+import io.kubernetes.client.common.KubernetesObject;
+import java.lang.reflect.Type;
+import okhttp3.Call;
+
+@OwnedBy(HarnessTeam.CDP)
+public interface K8sWatchClient {
+  <T extends KubernetesObject> boolean waitOnCondition(
+      Type type, ThrowingSupplier<Call> callSupplier, K8sEventPredicate<T> condition) throws Exception;
+}

--- a/960-api-services/src/main/java/io/harness/k8s/steadystate/watcher/client/K8sWatchClientFactory.java
+++ b/960-api-services/src/main/java/io/harness/k8s/steadystate/watcher/client/K8sWatchClientFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.k8s.steadystate.watcher.client;
+
+import io.harness.annotations.dev.HarnessTeam;
+import io.harness.annotations.dev.OwnedBy;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.inject.name.Named;
+import io.github.resilience4j.retry.Retry;
+import io.kubernetes.client.openapi.ApiClient;
+import java.util.concurrent.ExecutorService;
+
+@Singleton
+@OwnedBy(HarnessTeam.CDP)
+public class K8sWatchClientFactory {
+  @Inject @Named("k8sSteadyStateExecutor") private ExecutorService k8sSteadyStateExecutor;
+
+  public K8sWatchClient create(ApiClient apiClient, Retry retryConfig) {
+    return new K8sBlockingWatchClient(apiClient, retryConfig, k8sSteadyStateExecutor);
+  }
+}

--- a/960-api-services/src/main/java/io/harness/k8s/steadystate/watcher/workload/AbstractWorkloadWatcher.java
+++ b/960-api-services/src/main/java/io/harness/k8s/steadystate/watcher/workload/AbstractWorkloadWatcher.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+package io.harness.k8s.steadystate.watcher.workload;
+
+import io.harness.annotations.dev.HarnessTeam;
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.exception.ExceptionUtils;
+import io.harness.exception.KubernetesCliTaskRuntimeException;
+import io.harness.exception.sanitizer.ExceptionMessageSanitizer;
+import io.harness.k8s.model.KubernetesResourceId;
+import io.harness.k8s.steadystate.model.K8sStatusWatchDTO;
+import io.harness.logging.LogCallback;
+import io.harness.logging.LogLevel;
+
+import io.kubernetes.client.openapi.ApiException;
+import java.io.InterruptedIOException;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@OwnedBy(HarnessTeam.CDP)
+public abstract class AbstractWorkloadWatcher implements WorkloadWatcher {
+  @Override
+  public boolean watchRolloutStatus(K8sStatusWatchDTO k8SStatusWatchDTO, KubernetesResourceId workload,
+      LogCallback executionLogCallback) throws Exception {
+    try {
+      return watchRolloutStatusInternal(k8SStatusWatchDTO, workload, executionLogCallback);
+    } catch (ApiException e) {
+      ApiException ex = ExceptionMessageSanitizer.sanitizeException(e);
+      String errorMessage = String.format("Failed to watch rollout status for workload [%s]. ", workload.kindNameRef())
+          + ExceptionUtils.getMessage(ex);
+      log.error(errorMessage, ex);
+      executionLogCallback.saveExecutionLog(errorMessage, LogLevel.ERROR);
+      if (k8SStatusWatchDTO.isErrorFrameworkEnabled()) {
+        throw e;
+      }
+
+      return false;
+    } catch (KubernetesCliTaskRuntimeException e) {
+      KubernetesCliTaskRuntimeException ex = ExceptionMessageSanitizer.sanitizeException(e);
+      String errorMessage = String.format("Steady state check for workload [%s] did not succeed due to error: %s",
+          workload.kindNameRef(), ex.getMessage());
+      log.error(errorMessage, ex);
+      executionLogCallback.saveExecutionLog(errorMessage, LogLevel.ERROR);
+      if (k8SStatusWatchDTO.isErrorFrameworkEnabled()) {
+        throw e;
+      }
+
+      return false;
+    } catch (RuntimeException e) {
+      if (e.getCause() != null && e.getCause() instanceof InterruptedIOException) {
+        log.warn("Kubernetes watch was aborted.", e);
+        Thread.currentThread().interrupt();
+        return false;
+      }
+
+      log.error("Runtime exception during Kubernetes watch.", e);
+      throw e;
+    } catch (InterruptedException e) {
+      log.warn("Workload watch was interrupted");
+      if (k8SStatusWatchDTO.isErrorFrameworkEnabled()) {
+        throw e;
+      }
+
+      Thread.currentThread().interrupt();
+      return false;
+    } catch (Exception e) {
+      log.warn("Unhandled exception thrown", e);
+      if (k8SStatusWatchDTO.isErrorFrameworkEnabled()) {
+        throw e;
+      }
+
+      return false;
+    }
+  }
+
+  protected abstract boolean watchRolloutStatusInternal(K8sStatusWatchDTO k8SStatusWatchDTO,
+      KubernetesResourceId workload, LogCallback executionLogCallback) throws Exception;
+}

--- a/960-api-services/src/main/java/io/harness/k8s/steadystate/watcher/workload/BUILD.bazel
+++ b/960-api-services/src/main/java/io/harness/k8s/steadystate/watcher/workload/BUILD.bazel
@@ -19,6 +19,7 @@ java_library(
         "//960-api-services/src/main/java/io/harness/k8s/steadystate:module",
         "//960-api-services/src/main/java/io/harness/k8s/steadystate/model:module",
         "//960-api-services/src/main/java/io/harness/k8s/steadystate/statusviewer:module",
+        "//960-api-services/src/main/java/io/harness/k8s/steadystate/watcher/client:module",
         "//970-api-services-beans:module",
         "//980-commons/src/main/java/io/harness/configuration:module",
         "//980-commons/src/main/java/io/harness/data/structure:module",

--- a/960-api-services/src/main/java/io/harness/k8s/steadystate/watcher/workload/DeploymentApiWatcher.java
+++ b/960-api-services/src/main/java/io/harness/k8s/steadystate/watcher/workload/DeploymentApiWatcher.java
@@ -13,19 +13,19 @@ import static io.harness.k8s.steadystate.K8sSteadyStateConstants.WATCH_CALL_TIME
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.configuration.KubernetesCliCommandType;
 import io.harness.exception.KubernetesCliTaskRuntimeException;
-import io.harness.k8s.KubernetesContainerServiceImpl;
-import io.harness.k8s.WorkloadDetails;
 import io.harness.k8s.model.KubernetesResourceId;
 import io.harness.k8s.steadystate.model.K8ApiResponseDTO;
 import io.harness.k8s.steadystate.model.K8sStatusWatchDTO;
 import io.harness.k8s.steadystate.statusviewer.DeploymentStatusViewer;
+import io.harness.k8s.steadystate.watcher.client.K8sWatchClient;
+import io.harness.k8s.steadystate.watcher.client.K8sWatchClientFactory;
 import io.harness.logging.LogCallback;
 import io.harness.supplier.ThrowingSupplier;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.reflect.TypeToken;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.apis.AppsV1Api;
 import io.kubernetes.client.openapi.models.V1Deployment;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
@@ -37,54 +37,50 @@ import okhttp3.Call;
 @Singleton
 @Slf4j
 @OwnedBy(CDP)
-public class DeploymentApiWatcher implements WorkloadWatcher {
+public class DeploymentApiWatcher extends AbstractWorkloadWatcher {
   @Inject private DeploymentStatusViewer statusViewer;
-  @Inject private KubernetesContainerServiceImpl kubernetesContainerService;
-  private static final Type v1DeploymentType = new TypeToken<Watch.Response<V1Deployment>>() {}.getType();
+  @Inject private K8sWatchClientFactory watchClientFactory;
+  @VisibleForTesting static final Type v1DeploymentType = new TypeToken<Watch.Response<V1Deployment>>() {}.getType();
 
   @Override
-  public boolean watchRolloutStatus(K8sStatusWatchDTO k8SStatusWatchDTO, KubernetesResourceId workload,
+  protected boolean watchRolloutStatusInternal(K8sStatusWatchDTO k8SStatusWatchDTO, KubernetesResourceId workload,
       LogCallback executionLogCallback) throws Exception {
-    return watchDeploymentRetry(
-        k8SStatusWatchDTO.getApiClient(), workload, executionLogCallback, k8SStatusWatchDTO.isErrorFrameworkEnabled());
-  }
-
-  private boolean watchDeploymentRetry(ApiClient apiClient, KubernetesResourceId workload,
-      LogCallback executionLogCallback, boolean errorFrameworkEnabled) throws Exception {
-    AppsV1Api appsV1Api = new AppsV1Api(apiClient);
-    WorkloadDetails workloadDetails =
-        new WorkloadDetails(v1DeploymentType, apiClient, workload, executionLogCallback, errorFrameworkEnabled);
+    K8sWatchClient k8sWatchClient =
+        watchClientFactory.create(k8SStatusWatchDTO.getApiClient(), k8SStatusWatchDTO.getRetry());
+    AppsV1Api appsV1Api = new AppsV1Api(k8SStatusWatchDTO.getApiClient());
     ThrowingSupplier<Call> callSupplier = ()
         -> appsV1Api.listNamespacedDeploymentCall(workload.getNamespace(), null, null, null, null, null, null, null,
             null, WATCH_CALL_TIMEOUT_SECONDS, true, null);
-    return kubernetesContainerService.<V1Deployment>watchRetriesWrapper(workloadDetails, callSupplier, event -> {
-      V1Deployment deployment = event.object;
-      V1ObjectMeta meta = deployment.getMetadata();
-      if (meta == null || workload.getName().equals(meta.getName())) {
-        switch (event.type) {
-          case "ADDED":
-          case "MODIFIED":
-            K8ApiResponseDTO rolloutStatus = statusViewer.extractRolloutStatus(deployment);
-            executionLogCallback.saveExecutionLog(rolloutStatus.getMessage());
-            if (rolloutStatus.isFailed()) {
-              if (errorFrameworkEnabled) {
-                throw new KubernetesCliTaskRuntimeException(
-                    rolloutStatus.getMessage(), KubernetesCliCommandType.STEADY_STATE_CHECK);
-              }
-              return false;
-            }
-            if (rolloutStatus.isDone()) {
-              return true;
-            }
-            break;
-          case "DELETED":
+
+    return k8sWatchClient.<V1Deployment>waitOnCondition(
+        v1DeploymentType, callSupplier, event -> processEvent(event, workload, executionLogCallback));
+  }
+
+  private boolean processEvent(
+      Watch.Response<V1Deployment> event, KubernetesResourceId workload, LogCallback logCallback) throws Exception {
+    V1Deployment deployment = event.object;
+    V1ObjectMeta meta = deployment.getMetadata();
+    if (meta == null || workload.getName().equals(meta.getName())) {
+      switch (event.type) {
+        case "ADDED":
+        case "MODIFIED":
+          K8ApiResponseDTO rolloutStatus = statusViewer.extractRolloutStatus(deployment);
+          logCallback.saveExecutionLog(rolloutStatus.getMessage());
+          if (rolloutStatus.isFailed()) {
             throw new KubernetesCliTaskRuntimeException(
-                "object has been deleted", KubernetesCliCommandType.STEADY_STATE_CHECK);
-          default:
-            log.warn(String.format("Unexpected k8s event type %s", event.type));
-        }
+                rolloutStatus.getMessage(), KubernetesCliCommandType.STEADY_STATE_CHECK);
+          }
+          if (rolloutStatus.isDone()) {
+            return true;
+          }
+          break;
+        case "DELETED":
+          throw new KubernetesCliTaskRuntimeException(
+              "object has been deleted", KubernetesCliCommandType.STEADY_STATE_CHECK);
+        default:
+          log.warn(String.format("Unexpected k8s event type %s", event.type));
       }
-      return false;
-    });
+    }
+    return false;
   }
 }

--- a/960-api-services/src/main/java/io/harness/k8s/steadystate/watcher/workload/StatefulSetApiWatcher.java
+++ b/960-api-services/src/main/java/io/harness/k8s/steadystate/watcher/workload/StatefulSetApiWatcher.java
@@ -13,19 +13,19 @@ import static io.harness.k8s.steadystate.K8sSteadyStateConstants.WATCH_CALL_TIME
 import io.harness.annotations.dev.OwnedBy;
 import io.harness.configuration.KubernetesCliCommandType;
 import io.harness.exception.KubernetesCliTaskRuntimeException;
-import io.harness.k8s.KubernetesContainerServiceImpl;
-import io.harness.k8s.WorkloadDetails;
 import io.harness.k8s.model.KubernetesResourceId;
 import io.harness.k8s.steadystate.model.K8ApiResponseDTO;
 import io.harness.k8s.steadystate.model.K8sStatusWatchDTO;
 import io.harness.k8s.steadystate.statusviewer.StatefulSetStatusViewer;
+import io.harness.k8s.steadystate.watcher.client.K8sWatchClient;
+import io.harness.k8s.steadystate.watcher.client.K8sWatchClientFactory;
 import io.harness.logging.LogCallback;
 import io.harness.supplier.ThrowingSupplier;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.reflect.TypeToken;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.apis.AppsV1Api;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1StatefulSet;
@@ -37,54 +37,50 @@ import okhttp3.Call;
 @Singleton
 @Slf4j
 @OwnedBy(CDP)
-public class StatefulSetApiWatcher implements WorkloadWatcher {
+public class StatefulSetApiWatcher extends AbstractWorkloadWatcher {
   @Inject private StatefulSetStatusViewer statusViewer;
-  @Inject private KubernetesContainerServiceImpl kubernetesContainerService;
-  private static final Type v1StatefulSetType = new TypeToken<Watch.Response<V1StatefulSet>>() {}.getType();
+  @Inject private K8sWatchClientFactory watchClientFactory;
+  @VisibleForTesting static final Type v1StatefulSetType = new TypeToken<Watch.Response<V1StatefulSet>>() {}.getType();
 
   @Override
-  public boolean watchRolloutStatus(K8sStatusWatchDTO k8SStatusWatchDTO, KubernetesResourceId workload,
+  protected boolean watchRolloutStatusInternal(K8sStatusWatchDTO k8SStatusWatchDTO, KubernetesResourceId workload,
       LogCallback executionLogCallback) throws Exception {
-    return watchStatefulSetWithRetry(
-        k8SStatusWatchDTO.getApiClient(), workload, executionLogCallback, k8SStatusWatchDTO.isErrorFrameworkEnabled());
-  }
-
-  private boolean watchStatefulSetWithRetry(ApiClient apiClient, KubernetesResourceId workload,
-      LogCallback executionLogCallback, boolean errorFrameworkEnabled) throws Exception {
-    AppsV1Api appsV1Api = new AppsV1Api(apiClient);
-    WorkloadDetails workloadDetails =
-        new WorkloadDetails(v1StatefulSetType, apiClient, workload, executionLogCallback, errorFrameworkEnabled);
+    K8sWatchClient k8sWatchClient =
+        watchClientFactory.create(k8SStatusWatchDTO.getApiClient(), k8SStatusWatchDTO.getRetry());
+    AppsV1Api appsV1Api = new AppsV1Api(k8SStatusWatchDTO.getApiClient());
     ThrowingSupplier<Call> callSupplier = ()
         -> appsV1Api.listNamespacedStatefulSetCall(workload.getNamespace(), null, null, null, null, null, null, null,
             null, WATCH_CALL_TIMEOUT_SECONDS, true, null);
-    return kubernetesContainerService.<V1StatefulSet>watchRetriesWrapper(workloadDetails, callSupplier, event -> {
-      V1StatefulSet statefulSet = event.object;
-      V1ObjectMeta meta = statefulSet.getMetadata();
-      if (meta == null || workload.getName().equals(meta.getName())) {
-        switch (event.type) {
-          case "ADDED":
-          case "MODIFIED":
-            K8ApiResponseDTO rolloutStatus = statusViewer.extractRolloutStatus(statefulSet);
-            executionLogCallback.saveExecutionLog(rolloutStatus.getMessage());
-            if (rolloutStatus.isFailed()) {
-              if (errorFrameworkEnabled) {
-                throw new KubernetesCliTaskRuntimeException(
-                    rolloutStatus.getMessage(), KubernetesCliCommandType.STEADY_STATE_CHECK);
-              }
-              return false;
-            }
-            if (rolloutStatus.isDone()) {
-              return true;
-            }
-            break;
-          case "DELETED":
+    return k8sWatchClient.<V1StatefulSet>waitOnCondition(
+        v1StatefulSetType, callSupplier, event -> processEvent(event, workload, executionLogCallback));
+  }
+
+  private boolean processEvent(
+      Watch.Response<V1StatefulSet> event, KubernetesResourceId workload, LogCallback logCallback) {
+    V1StatefulSet statefulSet = event.object;
+    V1ObjectMeta meta = statefulSet.getMetadata();
+    if (meta == null || workload.getName().equals(meta.getName())) {
+      switch (event.type) {
+        case "ADDED":
+        case "MODIFIED":
+          K8ApiResponseDTO rolloutStatus = statusViewer.extractRolloutStatus(statefulSet);
+          logCallback.saveExecutionLog(rolloutStatus.getMessage());
+          if (rolloutStatus.isFailed()) {
             throw new KubernetesCliTaskRuntimeException(
-                "object has been deleted", KubernetesCliCommandType.STEADY_STATE_CHECK);
-          default:
-            log.warn(String.format("Unexpected k8s event type %s", event.type));
-        }
+                rolloutStatus.getMessage(), KubernetesCliCommandType.STEADY_STATE_CHECK);
+          }
+
+          if (rolloutStatus.isDone()) {
+            return true;
+          }
+          break;
+        case "DELETED":
+          throw new KubernetesCliTaskRuntimeException(
+              "object has been deleted", KubernetesCliCommandType.STEADY_STATE_CHECK);
+        default:
+          log.warn(String.format("Unexpected k8s event type %s", event.type));
       }
-      return false;
-    });
+    }
+    return false;
   }
 }

--- a/960-api-services/src/test/java/io/harness/k8s/steadystate/watcher/client/K8sBlockingWatchClientTest.java
+++ b/960-api-services/src/test/java/io/harness/k8s/steadystate/watcher/client/K8sBlockingWatchClientTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.k8s.steadystate.watcher.client;
+
+import static io.harness.annotations.dev.HarnessTeam.CDP;
+import static io.harness.rule.OwnerRule.ABOSII;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.harness.CategoryTest;
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.category.element.UnitTests;
+import io.harness.retry.RetryHelper;
+import io.harness.rule.Owner;
+import io.harness.supplier.ThrowingSupplier;
+
+import com.google.gson.reflect.TypeToken;
+import io.github.resilience4j.retry.Retry;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.JSON;
+import io.kubernetes.client.openapi.models.V1Deployment;
+import io.kubernetes.client.openapi.models.V1DeploymentBuilder;
+import io.kubernetes.client.util.Watch;
+import java.lang.reflect.Type;
+import java.net.SocketTimeoutException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.SneakyThrows;
+import okhttp3.Call;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import okio.BufferedSource;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+@OwnedBy(CDP)
+public class K8sBlockingWatchClientTest extends CategoryTest {
+  @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Mock private ApiClient apiClient;
+  @Mock private Call call;
+
+  private final Type v1DeploymentType = new TypeToken<Watch.Response<V1Deployment>>() {}.getType();
+  private final ThrowingSupplier<Call> callSupplier = () -> call;
+  private final JSON serializer = new JSON();
+  private final Retry retry = RetryHelper.getExponentialRetry("test-retry", new Class[] {SocketTimeoutException.class});
+
+  @Before
+  public void setup() {
+    doReturn(serializer).when(apiClient).getJSON();
+  }
+
+  @Test
+  @SneakyThrows
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testWaitOnCondition() {
+    final K8sWatchClient client = new K8sBlockingWatchClient(apiClient);
+
+    doReturn(createSimpleResponse()).when(call).execute();
+    boolean result = client.waitOnCondition(v1DeploymentType, callSupplier, event -> true);
+
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  @SneakyThrows
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testWaitOnConditionWithRetriesAndFailedCondition() {
+    final AtomicInteger callCount = new AtomicInteger();
+    final K8sWatchClient client = new K8sBlockingWatchClient(apiClient, retry);
+
+    doAnswer(i -> {
+      callCount.incrementAndGet();
+      return createSimpleResponse();
+    })
+        .when(call)
+        .execute();
+
+    assertThatThrownBy(() -> client.waitOnCondition(v1DeploymentType, callSupplier, event -> {
+      throw new RuntimeException("failed condition");
+    })).hasStackTraceContaining("failed condition");
+    // Condition fail shouldn't be a reason for retry;
+    assertThat(callCount.get()).isEqualTo(1);
+  }
+
+  @Test
+  @SneakyThrows
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testWaitOnConditionMultipleEvents() {
+    final AtomicInteger count = new AtomicInteger(4);
+    final K8sWatchClient client = new K8sBlockingWatchClient(apiClient);
+
+    doAnswer(invocation -> {
+      Thread.sleep(50);
+      return createSimpleResponse();
+    })
+        .when(call)
+        .execute();
+
+    boolean result = client.waitOnCondition(v1DeploymentType, callSupplier, event -> count.decrementAndGet() <= 0);
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  @SneakyThrows
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testWaitOnConditionWithRetries() {
+    final AtomicInteger retryCount = new AtomicInteger();
+    final K8sWatchClient client = new K8sBlockingWatchClient(apiClient, retry);
+
+    doAnswer(invocation -> {
+      int count = retryCount.incrementAndGet();
+      if (count < 3) {
+        throw new SocketTimeoutException();
+      }
+
+      return createSimpleResponse();
+    })
+        .when(call)
+        .execute();
+
+    boolean result = client.waitOnCondition(v1DeploymentType, callSupplier, event -> true);
+    assertThat(result).isTrue();
+    assertThat(retryCount.get()).isEqualTo(3);
+  }
+
+  @Test
+  @SneakyThrows
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testWaitOnConditionWithRetriesFailed() {
+    final AtomicInteger retryCount = new AtomicInteger();
+    final K8sWatchClient client = new K8sBlockingWatchClient(apiClient, retry);
+
+    doAnswer(invocation -> {
+      retryCount.incrementAndGet();
+      throw new SocketTimeoutException();
+    })
+        .when(call)
+        .execute();
+
+    assertThatThrownBy(() -> client.waitOnCondition(v1DeploymentType, callSupplier, event -> true))
+        .hasStackTraceContaining(SocketTimeoutException.class.getName());
+    assertThat(retryCount.get()).isEqualTo(3);
+  }
+
+  @Test
+  @SneakyThrows
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testWaitOnConditionFailedScheduling() {
+    final ExecutorService mockExecutor = mock(ExecutorService.class);
+    final K8sWatchClient client = new K8sBlockingWatchClient(apiClient, retry, mockExecutor);
+
+    doThrow(new RejectedExecutionException("Failed to schedule")).when(mockExecutor).submit(any(Callable.class));
+
+    doReturn(createSimpleResponse()).when(call).execute();
+    boolean result = client.waitOnCondition(v1DeploymentType, callSupplier, event -> true);
+    assertThat(result).isTrue();
+    verify(mockExecutor).submit(any(Callable.class));
+  }
+
+  @SneakyThrows
+  private Response createSimpleResponse() {
+    ResponseBody mockBody = mock(ResponseBody.class);
+    String bodyResponse = getWatchResponseJson();
+    BufferedSource mockSource = mock(BufferedSource.class);
+
+    Response response = new Response.Builder()
+                            .protocol(Protocol.HTTP_1_1)
+                            .message("test message")
+                            .request(new Request.Builder()
+                                         .url("https://test.cluster.dv")
+
+                                         .build())
+                            .body(mockBody)
+                            .code(200)
+                            .build();
+
+    doReturn(bodyResponse).when(mockBody).string();
+    doReturn(mockSource).when(mockBody).source();
+    doReturn(bodyResponse).when(mockSource).readUtf8Line();
+    doReturn(bodyResponse).when(mockSource).readUtf8();
+
+    return response;
+  }
+
+  private String getWatchResponseJson() {
+    return serializer.serialize(new Watch.Response<>("ADDED", new V1DeploymentBuilder().build()));
+  }
+}

--- a/960-api-services/src/test/java/io/harness/k8s/steadystate/watcher/workload/AbstractWorkloadWatcherTest.java
+++ b/960-api-services/src/test/java/io/harness/k8s/steadystate/watcher/workload/AbstractWorkloadWatcherTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+package io.harness.k8s.steadystate.watcher.workload;
+
+import static io.harness.rule.OwnerRule.ABOSII;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+
+import io.harness.CategoryTest;
+import io.harness.annotations.dev.HarnessTeam;
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.category.element.UnitTests;
+import io.harness.configuration.KubernetesCliCommandType;
+import io.harness.exception.KubernetesCliTaskRuntimeException;
+import io.harness.k8s.model.KubernetesResourceId;
+import io.harness.k8s.steadystate.model.K8sStatusWatchDTO;
+import io.harness.logging.LogCallback;
+import io.harness.rule.Owner;
+
+import io.kubernetes.client.openapi.ApiException;
+import lombok.SneakyThrows;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+@OwnedBy(HarnessTeam.CDP)
+public class AbstractWorkloadWatcherTest extends CategoryTest {
+  @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  private final K8sStatusWatchDTO watchDTO = K8sStatusWatchDTO.builder().build();
+  private final KubernetesResourceId workloadId = KubernetesResourceId.builder().build();
+
+  @Spy private AbstractWorkloadWatcher abstractWorkloadWatcher;
+
+  @Mock private LogCallback logCallback;
+
+  @Test
+  @SneakyThrows
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testWatchRolloutStatusSuccessful() {
+    doReturn(true).when(abstractWorkloadWatcher).watchRolloutStatusInternal(watchDTO, workloadId, logCallback);
+    boolean result = abstractWorkloadWatcher.watchRolloutStatus(watchDTO, workloadId, logCallback);
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  @SneakyThrows
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testWatchRolloutStatusApiException() {
+    testWatchRolloutStatusFailure(new ApiException("Something went wrong"), false);
+  }
+
+  @Test
+  @SneakyThrows
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testWatchRolloutStatusKubernetesCliTaskRuntimeException() {
+    testWatchRolloutStatusFailure(
+        new KubernetesCliTaskRuntimeException("Failed to watch", KubernetesCliCommandType.STEADY_STATE_CHECK), false);
+  }
+
+  @Test
+  @SneakyThrows
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testWatchRolloutStatusRuntimeException() {
+    testWatchRolloutStatusFailure(new RuntimeException("Unexpected"), true);
+  }
+
+  @Test
+  @SneakyThrows
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testWatchRolloutStatusInterruptedException() {
+    testWatchRolloutStatusFailure(new InterruptedException(), false);
+  }
+
+  @Test
+  @SneakyThrows
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testWatchRolloutStatusUnhandledException() {
+    testWatchRolloutStatusFailure(new UnknownTestException(), false);
+  }
+
+  @SneakyThrows
+  private void testWatchRolloutStatusFailure(Exception exception, boolean throwEvenIfErrorFrameworkDisabled) {
+    doThrow(exception).when(abstractWorkloadWatcher).watchRolloutStatusInternal(watchDTO, workloadId, logCallback);
+
+    // error framework disabled
+    watchDTO.setErrorFrameworkEnabled(false);
+    if (throwEvenIfErrorFrameworkDisabled) {
+      assertThatThrownBy(() -> abstractWorkloadWatcher.watchRolloutStatus(watchDTO, workloadId, logCallback))
+          .isInstanceOf(exception.getClass());
+    } else {
+      boolean result = abstractWorkloadWatcher.watchRolloutStatus(watchDTO, workloadId, logCallback);
+      assertThat(result).isFalse();
+    }
+
+    // error framework enabled
+    watchDTO.setErrorFrameworkEnabled(true);
+    assertThatThrownBy(() -> abstractWorkloadWatcher.watchRolloutStatusInternal(watchDTO, workloadId, logCallback))
+        .isInstanceOf(exception.getClass());
+  }
+
+  private static class UnknownTestException extends Exception {};
+}

--- a/960-api-services/src/test/java/io/harness/k8s/steadystate/watcher/workload/ApiWatcherTestBase.java
+++ b/960-api-services/src/test/java/io/harness/k8s/steadystate/watcher/workload/ApiWatcherTestBase.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+package io.harness.k8s.steadystate.watcher.workload;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+
+import io.harness.CategoryTest;
+import io.harness.annotations.dev.HarnessTeam;
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.k8s.steadystate.model.K8sStatusWatchDTO;
+import io.harness.k8s.steadystate.watcher.client.K8sEventPredicate;
+import io.harness.k8s.steadystate.watcher.client.K8sWatchClient;
+import io.harness.k8s.steadystate.watcher.client.K8sWatchClientFactory;
+import io.harness.logging.LogCallback;
+import io.harness.supplier.ThrowingSupplier;
+
+import io.github.resilience4j.retry.Retry;
+import io.kubernetes.client.common.KubernetesObject;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.util.Watch;
+import java.lang.reflect.Type;
+import lombok.SneakyThrows;
+import org.junit.Before;
+import org.junit.Rule;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+@OwnedBy(HarnessTeam.CDP)
+public abstract class ApiWatcherTestBase<T extends KubernetesObject> extends CategoryTest {
+  @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Mock protected LogCallback logCallback;
+  @Mock protected ApiClient apiClient;
+  @Mock protected Retry retry;
+  @Mock protected K8sWatchClient watchClient;
+  @Mock protected K8sWatchClientFactory watchClientFactory;
+
+  @Before
+  public void baseSetup() {
+    doReturn(watchClient).when(watchClientFactory).create(any(ApiClient.class), any(Retry.class));
+  }
+
+  @SneakyThrows
+  protected void prepareWatchClient(Type type, Watch.Response<T> eventResponse) {
+    doAnswer(invocation -> ((K8sEventPredicate<T>) invocation.getArgument(2)).test(eventResponse))
+        .when(watchClient)
+        .waitOnCondition(eq(type), any(ThrowingSupplier.class), any(K8sEventPredicate.class));
+  }
+
+  protected K8sStatusWatchDTO createTestDTO() {
+    return K8sStatusWatchDTO.builder().apiClient(apiClient).retry(retry).build();
+  }
+
+  protected Watch.Response<T> createAddedWatchResponse(T object) {
+    return createWatchResponse("ADDED", object);
+  }
+
+  protected Watch.Response<T> createModifiedWatchResponse(T object) {
+    return createWatchResponse("MODIFIED", object);
+  }
+
+  protected Watch.Response<T> createDeletedWatchResponse(T object) {
+    return createWatchResponse("DELETED", object);
+  }
+
+  protected Watch.Response<T> createUnknownWatchResponse(T object) {
+    return createWatchResponse("UNKNOWN", object);
+  }
+
+  protected Watch.Response<T> createWatchResponse(String type, T object) {
+    return new Watch.Response<>(type, object);
+  }
+}

--- a/960-api-services/src/test/java/io/harness/k8s/steadystate/watcher/workload/DaemonSetApiWatcherTest.java
+++ b/960-api-services/src/test/java/io/harness/k8s/steadystate/watcher/workload/DaemonSetApiWatcherTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+package io.harness.k8s.steadystate.watcher.workload;
+
+import static io.harness.rule.OwnerRule.ABOSII;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doReturn;
+
+import io.harness.annotations.dev.HarnessTeam;
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.category.element.UnitTests;
+import io.harness.exception.KubernetesCliTaskRuntimeException;
+import io.harness.k8s.model.KubernetesResourceId;
+import io.harness.k8s.steadystate.model.K8ApiResponseDTO;
+import io.harness.k8s.steadystate.statusviewer.DaemonSetStatusViewer;
+import io.harness.rule.Owner;
+
+import io.kubernetes.client.openapi.models.V1DaemonSet;
+import io.kubernetes.client.openapi.models.V1DaemonSetBuilder;
+import io.kubernetes.client.openapi.models.V1DaemonSetSpecBuilder;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1ObjectMetaBuilder;
+import lombok.SneakyThrows;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+@OwnedBy(HarnessTeam.CDP)
+public class DaemonSetApiWatcherTest extends ApiWatcherTestBase<V1DaemonSet> {
+  @Mock private DaemonSetStatusViewer statusViewer;
+
+  @InjectMocks private DaemonSetApiWatcher daemonSetApiWatcher;
+
+  private final V1ObjectMeta metadata = new V1ObjectMetaBuilder().withName("test-resource").build();
+  private final V1DaemonSet successfulDaemonSet =
+      new V1DaemonSetBuilder()
+          .withMetadata(metadata)
+          .withSpec(
+              new V1DaemonSetSpecBuilder().withMinReadySeconds(10).build()) // added to not be equal with failed one
+          .build();
+  private final V1DaemonSet failedDaemonSet =
+      new V1DaemonSetBuilder()
+          .withMetadata(metadata)
+          .withSpec(new V1DaemonSetSpecBuilder().withMinReadySeconds(20).build())
+          .build();
+
+  @Before
+  public void setup() {
+    doReturn(K8ApiResponseDTO.builder().isFailed(true).message("Failed to reach steady state").build())
+        .when(statusViewer)
+        .extractRolloutStatus(failedDaemonSet);
+    doReturn(K8ApiResponseDTO.builder().isDone(true).build())
+        .when(statusViewer)
+        .extractRolloutStatus(successfulDaemonSet);
+  }
+
+  @Test
+  @SneakyThrows
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testWatchRolloutStatusSuccessful() {
+    prepareWatchClient(DaemonSetApiWatcher.v1DaemonSetType, createAddedWatchResponse(successfulDaemonSet));
+    boolean result =
+        daemonSetApiWatcher.watchRolloutStatusInternal(createTestDTO(), createTestResourceId(), logCallback);
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  @SneakyThrows
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testWatchRolloutStatusSuccessfulModifiedEvent() {
+    prepareWatchClient(DaemonSetApiWatcher.v1DaemonSetType, createModifiedWatchResponse(successfulDaemonSet));
+    boolean result =
+        daemonSetApiWatcher.watchRolloutStatusInternal(createTestDTO(), createTestResourceId(), logCallback);
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  @SneakyThrows
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testWatchRolloutStatusFailed() {
+    prepareWatchClient(DaemonSetApiWatcher.v1DaemonSetType, createAddedWatchResponse(failedDaemonSet));
+    assertThatThrownBy(
+        () -> daemonSetApiWatcher.watchRolloutStatusInternal(createTestDTO(), createTestResourceId(), logCallback))
+        .isInstanceOf(KubernetesCliTaskRuntimeException.class)
+        .hasStackTraceContaining("Failed to reach steady state");
+  }
+
+  @Test
+  @SneakyThrows
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testWatchRolloutStatusDeleted() {
+    prepareWatchClient(DaemonSetApiWatcher.v1DaemonSetType, createDeletedWatchResponse(failedDaemonSet));
+    assertThatThrownBy(
+        () -> daemonSetApiWatcher.watchRolloutStatusInternal(createTestDTO(), createTestResourceId(), logCallback))
+        .isInstanceOf(KubernetesCliTaskRuntimeException.class)
+        .hasStackTraceContaining("object has been deleted");
+  }
+
+  @Test
+  @SneakyThrows
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testWatchRolloutStatusUnknownEvent() {
+    prepareWatchClient(DaemonSetApiWatcher.v1DaemonSetType, createUnknownWatchResponse(failedDaemonSet));
+    boolean result =
+        daemonSetApiWatcher.watchRolloutStatusInternal(createTestDTO(), createTestResourceId(), logCallback);
+
+    // This is the result of the processEvent method returning false as part of the mock.
+    // In real scenario K8sWatchClient#waitOnCondition will continue to watch for resource and will not
+    // return while a known event will be received and resource failed. If logic change this test need to be
+    assertThat(result).isFalse();
+  }
+
+  private KubernetesResourceId createTestResourceId() {
+    return KubernetesResourceId.builder().kind("DaemonSet").name("test-resource").build();
+  }
+}

--- a/960-api-services/src/test/java/io/harness/k8s/steadystate/watcher/workload/DeploymentApiWatcherTest.java
+++ b/960-api-services/src/test/java/io/harness/k8s/steadystate/watcher/workload/DeploymentApiWatcherTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+package io.harness.k8s.steadystate.watcher.workload;
+
+import static io.harness.rule.OwnerRule.ABOSII;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doReturn;
+
+import io.harness.annotations.dev.HarnessTeam;
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.category.element.UnitTests;
+import io.harness.exception.KubernetesCliTaskRuntimeException;
+import io.harness.k8s.model.KubernetesResourceId;
+import io.harness.k8s.steadystate.model.K8ApiResponseDTO;
+import io.harness.k8s.steadystate.statusviewer.DeploymentStatusViewer;
+import io.harness.rule.Owner;
+
+import io.kubernetes.client.openapi.models.V1Deployment;
+import io.kubernetes.client.openapi.models.V1DeploymentBuilder;
+import io.kubernetes.client.openapi.models.V1DeploymentSpecBuilder;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1ObjectMetaBuilder;
+import lombok.SneakyThrows;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+@OwnedBy(HarnessTeam.CDP)
+public class DeploymentApiWatcherTest extends ApiWatcherTestBase<V1Deployment> {
+  @Mock private DeploymentStatusViewer statusViewer;
+
+  @InjectMocks private DeploymentApiWatcher deploymentApiWatcher;
+
+  private final V1ObjectMeta metadata = new V1ObjectMetaBuilder().withName("test-resource").build();
+  private final V1Deployment successfulDeployment =
+      new V1DeploymentBuilder()
+          .withMetadata(metadata)
+          .withSpec(new V1DeploymentSpecBuilder().withReplicas(1).build()) // added to not be equal with failed one
+          .build();
+  private final V1Deployment failedDeployment = new V1DeploymentBuilder()
+                                                    .withMetadata(metadata)
+                                                    .withSpec(new V1DeploymentSpecBuilder().withReplicas(3).build())
+                                                    .build();
+
+  @Before
+  public void setup() {
+    doReturn(K8ApiResponseDTO.builder().isFailed(true).message("Failed to reach steady state").build())
+        .when(statusViewer)
+        .extractRolloutStatus(failedDeployment);
+    doReturn(K8ApiResponseDTO.builder().isDone(true).build())
+        .when(statusViewer)
+        .extractRolloutStatus(successfulDeployment);
+  }
+
+  @Test
+  @SneakyThrows
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testWatchRolloutStatusSuccessful() {
+    prepareWatchClient(DeploymentApiWatcher.v1DeploymentType, createAddedWatchResponse(successfulDeployment));
+    boolean result =
+        deploymentApiWatcher.watchRolloutStatusInternal(createTestDTO(), createTestResourceId(), logCallback);
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  @SneakyThrows
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testWatchRolloutStatusSuccessfulModifiedEvent() {
+    prepareWatchClient(DeploymentApiWatcher.v1DeploymentType, createModifiedWatchResponse(successfulDeployment));
+    boolean result =
+        deploymentApiWatcher.watchRolloutStatusInternal(createTestDTO(), createTestResourceId(), logCallback);
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  @SneakyThrows
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testWatchRolloutStatusFailed() {
+    prepareWatchClient(DeploymentApiWatcher.v1DeploymentType, createAddedWatchResponse(failedDeployment));
+    assertThatThrownBy(
+        () -> deploymentApiWatcher.watchRolloutStatusInternal(createTestDTO(), createTestResourceId(), logCallback))
+        .isInstanceOf(KubernetesCliTaskRuntimeException.class)
+        .hasStackTraceContaining("Failed to reach steady state");
+  }
+
+  @Test
+  @SneakyThrows
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testWatchRolloutStatusDeleted() {
+    prepareWatchClient(DeploymentApiWatcher.v1DeploymentType, createDeletedWatchResponse(failedDeployment));
+    assertThatThrownBy(
+        () -> deploymentApiWatcher.watchRolloutStatusInternal(createTestDTO(), createTestResourceId(), logCallback))
+        .isInstanceOf(KubernetesCliTaskRuntimeException.class)
+        .hasStackTraceContaining("object has been deleted");
+  }
+
+  @Test
+  @SneakyThrows
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testWatchRolloutStatusUnknownEvent() {
+    prepareWatchClient(DeploymentApiWatcher.v1DeploymentType, createUnknownWatchResponse(failedDeployment));
+    boolean result =
+        deploymentApiWatcher.watchRolloutStatusInternal(createTestDTO(), createTestResourceId(), logCallback);
+
+    // This is the result of the processEvent method returning false as part of the mock.
+    // In real scenario K8sWatchClient#waitOnCondition will continue to watch for resource and will not
+    // return while a known event will be received and resource failed. If logic change this test need to be
+    assertThat(result).isFalse();
+  }
+
+  private KubernetesResourceId createTestResourceId() {
+    return KubernetesResourceId.builder().kind("Deployment").name("test-resource").build();
+  }
+}

--- a/960-api-services/src/test/java/io/harness/k8s/steadystate/watcher/workload/StatefulSetApiWatcherTest.java
+++ b/960-api-services/src/test/java/io/harness/k8s/steadystate/watcher/workload/StatefulSetApiWatcherTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Shield 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/06/PolyForm-Shield-1.0.0.txt.
+ */
+
+package io.harness.k8s.steadystate.watcher.workload;
+
+import static io.harness.rule.OwnerRule.ABOSII;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doReturn;
+
+import io.harness.annotations.dev.HarnessTeam;
+import io.harness.annotations.dev.OwnedBy;
+import io.harness.category.element.UnitTests;
+import io.harness.exception.KubernetesCliTaskRuntimeException;
+import io.harness.k8s.model.KubernetesResourceId;
+import io.harness.k8s.steadystate.model.K8ApiResponseDTO;
+import io.harness.k8s.steadystate.statusviewer.StatefulSetStatusViewer;
+import io.harness.rule.Owner;
+
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1ObjectMetaBuilder;
+import io.kubernetes.client.openapi.models.V1StatefulSet;
+import io.kubernetes.client.openapi.models.V1StatefulSetBuilder;
+import io.kubernetes.client.openapi.models.V1StatefulSetSpecBuilder;
+import lombok.SneakyThrows;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+@OwnedBy(HarnessTeam.CDP)
+public class StatefulSetApiWatcherTest extends ApiWatcherTestBase<V1StatefulSet> {
+  @Mock private StatefulSetStatusViewer statusViewer;
+
+  @InjectMocks private StatefulSetApiWatcher statefulSetApiWatcher;
+
+  private final V1ObjectMeta metadata = new V1ObjectMetaBuilder().withName("test-resource").build();
+  private final V1StatefulSet successfulStatefulSet =
+      new V1StatefulSetBuilder()
+          .withMetadata(metadata)
+          .withSpec(new V1StatefulSetSpecBuilder().withReplicas(7).build()) // added to not be equal with failed one
+          .build();
+  private final V1StatefulSet failedStatefulSet = new V1StatefulSetBuilder()
+                                                      .withMetadata(metadata)
+                                                      .withSpec(new V1StatefulSetSpecBuilder().withReplicas(10).build())
+                                                      .build();
+
+  @Before
+  public void setup() {
+    doReturn(K8ApiResponseDTO.builder().isFailed(true).message("Failed to reach steady state").build())
+        .when(statusViewer)
+        .extractRolloutStatus(failedStatefulSet);
+    doReturn(K8ApiResponseDTO.builder().isDone(true).build())
+        .when(statusViewer)
+        .extractRolloutStatus(successfulStatefulSet);
+  }
+
+  @Test
+  @SneakyThrows
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testWatchRolloutStatusSuccessful() {
+    prepareWatchClient(StatefulSetApiWatcher.v1StatefulSetType, createAddedWatchResponse(successfulStatefulSet));
+    boolean result =
+        statefulSetApiWatcher.watchRolloutStatusInternal(createTestDTO(), createTestResourceId(), logCallback);
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  @SneakyThrows
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testWatchRolloutStatusSuccessfulModifiedEvent() {
+    prepareWatchClient(StatefulSetApiWatcher.v1StatefulSetType, createModifiedWatchResponse(successfulStatefulSet));
+    boolean result =
+        statefulSetApiWatcher.watchRolloutStatusInternal(createTestDTO(), createTestResourceId(), logCallback);
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  @SneakyThrows
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testWatchRolloutStatusFailed() {
+    prepareWatchClient(StatefulSetApiWatcher.v1StatefulSetType, createAddedWatchResponse(failedStatefulSet));
+    assertThatThrownBy(
+        () -> statefulSetApiWatcher.watchRolloutStatusInternal(createTestDTO(), createTestResourceId(), logCallback))
+        .isInstanceOf(KubernetesCliTaskRuntimeException.class)
+        .hasStackTraceContaining("Failed to reach steady state");
+  }
+
+  @Test
+  @SneakyThrows
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testWatchRolloutStatusDeleted() {
+    prepareWatchClient(StatefulSetApiWatcher.v1StatefulSetType, createDeletedWatchResponse(failedStatefulSet));
+    assertThatThrownBy(
+        () -> statefulSetApiWatcher.watchRolloutStatusInternal(createTestDTO(), createTestResourceId(), logCallback))
+        .isInstanceOf(KubernetesCliTaskRuntimeException.class)
+        .hasStackTraceContaining("object has been deleted");
+  }
+
+  @Test
+  @SneakyThrows
+  @Owner(developers = ABOSII)
+  @Category(UnitTests.class)
+  public void testWatchRolloutStatusUnknownEvent() {
+    prepareWatchClient(DaemonSetApiWatcher.v1DaemonSetType, createUnknownWatchResponse(failedStatefulSet));
+    boolean result =
+        statefulSetApiWatcher.watchRolloutStatusInternal(createTestDTO(), createTestResourceId(), logCallback);
+
+    // This is the result of the processEvent method returning false as part of the mock.
+    // In real scenario K8sWatchClient#waitOnCondition will continue to watch for resource and will not
+    // return while a known event will be received and resource failed. If logic change this test need to be
+    assertThat(result).isFalse();
+  }
+
+  private KubernetesResourceId createTestResourceId() {
+    return KubernetesResourceId.builder().kind("StatefulSet").name("test-resource").build();
+  }
+}


### PR DESCRIPTION
* fix: [CDS-58702]: Fix and refactor API steady state uninterruptible socket read

* fix: [CDS-58702]: Add cached thread executor service

* fix: [CDS-58702]: Fix steadystate/model/build.bazel format

* fix: [CDS-58702]: Move executor service to client factory and check fixes

* fix: [CDS-58702]: Try to ignore base test