### PR TITLE
[techdebt]: [SRM-14680]: changing the logic for reading from activity… (#47541)

### DIFF
--- a/srm-service/modules/cv-nextgen-service/service/src/main/java/io/harness/cvng/activity/entities/ActivityBucket.java
+++ b/srm-service/modules/cv-nextgen-service/service/src/main/java/io/harness/cvng/activity/entities/ActivityBucket.java
@@ -46,7 +46,7 @@ public class ActivityBucket implements PersistentEntity, UuidAware, CreatedAtAwa
   public static List<MongoIndex> mongoIndexes() {
     return ImmutableList.<MongoIndex>builder()
         .add(CompoundMongoIndex.builder()
-                 .name("change_event_event_time_sort_query_indexv2")
+                 .name("change_event_time_sort_query_index")
                  .field(ActivityBucketKeys.accountId)
                  .field(ActivityBucketKeys.orgIdentifier)
                  .field(ActivityBucketKeys.projectIdentifier)
@@ -60,12 +60,11 @@ public class ActivityBucket implements PersistentEntity, UuidAware, CreatedAtAwa
   @Id private String uuid;
   private long createdAt;
   private long lastUpdatedAt;
-
   @NotNull private ActivityType type;
   @NotNull private String accountId;
   @NotNull private String projectIdentifier;
   @NotNull private String orgIdentifier;
-  List<String> monitoredServiceIdentifiers;
+  private List<String> monitoredServiceIdentifiers;
   private Instant bucketTime;
   private Long count;
   @Builder.Default @FdTtlIndex private Date validUntil = Date.from(OffsetDateTime.now().plusMonths(2).toInstant());

--- a/srm-service/modules/cv-nextgen-service/service/src/main/java/io/harness/cvng/activity/entities/InternalChangeActivity.java
+++ b/srm-service/modules/cv-nextgen-service/service/src/main/java/io/harness/cvng/activity/entities/InternalChangeActivity.java
@@ -66,7 +66,9 @@ public class InternalChangeActivity extends Activity {
 
     public Query<InternalChangeActivity> populateKeyQuery(
         Query<InternalChangeActivity> query, InternalChangeActivity activity) {
-      return super.populateKeyQuery(query, activity).filter(ActivityKeys.eventTime, activity.getEventTime());
+      return super.populateKeyQuery(query, activity)
+          .filter(ActivityKeys.eventTime, activity.getEventTime())
+          .filter(ActivityKeys.type, activity.getType());
     }
 
     @Override

--- a/srm-service/modules/cv-nextgen-service/service/src/main/java/io/harness/cvng/activity/services/impl/ActivityServiceImpl.java
+++ b/srm-service/modules/cv-nextgen-service/service/src/main/java/io/harness/cvng/activity/services/impl/ActivityServiceImpl.java
@@ -200,6 +200,8 @@ public class ActivityServiceImpl implements ActivityService {
             .filter(ActivityBucketKeys.orgIdentifier, activityBucket.getOrgIdentifier())
             .filter(ActivityBucketKeys.projectIdentifier, activityBucket.getProjectIdentifier())
             .filter(ActivityBucketKeys.monitoredServiceIdentifiers, activityBucket.getMonitoredServiceIdentifiers())
+            .filter(ActivityBucketKeys.type, activityBucket.getType())
+            .filter(ActivityKeys.validUntil, activityBucket.getBucketTime())
             .filter(ActivityBucketKeys.bucketTime, activityBucket.getBucketTime());
     UpdateOperations<ActivityBucket> updateOperations = hPersistence.createUpdateOperations(ActivityBucket.class);
     updateOperations.inc(ActivityBucketKeys.count);

--- a/srm-service/modules/cv-nextgen-service/service/src/main/java/io/harness/cvng/core/services/impl/ChangeEventServiceImpl.java
+++ b/srm-service/modules/cv-nextgen-service/service/src/main/java/io/harness/cvng/core/services/impl/ChangeEventServiceImpl.java
@@ -7,6 +7,8 @@
 
 package io.harness.cvng.core.services.impl;
 
+import static io.harness.cvng.core.utils.DateTimeUtils.roundDownTo5MinBoundary;
+import static io.harness.cvng.core.utils.DateTimeUtils.roundUpTo5MinBoundary;
 import static io.harness.data.structure.EmptyPredicate.isEmpty;
 import static io.harness.data.structure.EmptyPredicate.isNotEmpty;
 import static io.harness.persistence.HQuery.QueryChecks.COUNT;
@@ -17,6 +19,8 @@ import static dev.morphia.aggregation.Group.id;
 
 import io.harness.cvng.activity.entities.Activity;
 import io.harness.cvng.activity.entities.Activity.ActivityKeys;
+import io.harness.cvng.activity.entities.ActivityBucket;
+import io.harness.cvng.activity.entities.ActivityBucket.ActivityBucketKeys;
 import io.harness.cvng.activity.entities.KubernetesClusterActivity.KubernetesClusterActivityKeys;
 import io.harness.cvng.activity.entities.KubernetesClusterActivity.RelatedAppMonitoredService.ServiceEnvironmentKeys;
 import io.harness.cvng.activity.services.api.ActivityService;
@@ -226,6 +230,8 @@ public class ChangeEventServiceImpl implements ChangeEventService {
       List<String> environmentIdentifiers, List<String> monitoredServiceIdentifiers,
       boolean isMonitoredServiceIdentifierScoped, String searchText, List<ChangeCategory> changeCategories,
       List<ChangeSourceType> changeSourceTypes, Instant startTime, Instant endTime, Integer pointCount) {
+    startTime = roundDownTo5MinBoundary(startTime);
+    endTime = roundUpTo5MinBoundary(endTime);
     if (isNotEmpty(monitoredServiceIdentifiers)) {
       Preconditions.checkState(isEmpty(serviceIdentifiers) && isEmpty(environmentIdentifiers),
           "serviceIdentifier, envIdentifier filter can not be used with monitoredServiceIdentifier filter");
@@ -255,24 +261,26 @@ public class ChangeEventServiceImpl implements ChangeEventService {
       boolean isMonitoredServiceIdentifierScoped) {
     Duration timeRangeDuration = Duration.between(startTime, endTime).dividedBy(pointCount);
     AggregationPipeline aggregationPipeline =
-        hPersistence.getDatastore(Activity.class)
-            .createAggregation(Activity.class)
-            .match(createQuery(startTime, endTime, projectParams, monitoredServiceIdentifiers, searchText,
-                changeCategories, changeSourceTypes, isMonitoredServiceIdentifierScoped))
+        hPersistence.getDatastore(ActivityBucket.class)
+            .createAggregation(ActivityBucket.class)
+            .match(createQueryForActivityBucket(startTime, endTime, projectParams, monitoredServiceIdentifiers,
+                searchText, changeCategories, changeSourceTypes, isMonitoredServiceIdentifierScoped))
             .group(id(grouping("type", "type"),
                        grouping("index",
                            accumulator("$floor",
                                accumulator("$divide",
                                    Arrays.asList(accumulator("$subtract",
-                                                     Arrays.asList("$eventTime", new Date(startTime.toEpochMilli()))),
+                                                     Arrays.asList("$bucketTime", new Date(startTime.toEpochMilli()))),
                                        timeRangeDuration.toMillis()))))),
-                grouping("count", accumulator("$sum", 1)));
-    int limit = hPersistence.getMaxDocumentLimit(Activity.class);
+                grouping("count", accumulator("$sum", "count")));
+    int limit = hPersistence.getMaxDocumentLimit(ActivityBucket.class);
     if (limit > 0) {
       aggregationPipeline.limit(limit);
     }
     return aggregationPipeline.aggregate(TimelineObject.class,
-        AggregationOptions.builder().maxTime(hPersistence.getMaxTimeMs(Activity.class), TimeUnit.MILLISECONDS).build());
+        AggregationOptions.builder()
+            .maxTime(hPersistence.getMaxTimeMs(ActivityBucket.class), TimeUnit.MILLISECONDS)
+            .build());
   }
   @VisibleForTesting
   Iterator<TimelineObject> getTimelineObject(ProjectParams projectParams, List<String> serviceIdentifiers,
@@ -312,6 +320,8 @@ public class ChangeEventServiceImpl implements ChangeEventService {
       Instant endTime, boolean isMonitoredServiceIdentifierScoped) {
     Map<ChangeCategory, Map<Integer, Integer>> changeCategoryToIndexToCount =
         Arrays.stream(ChangeCategory.values()).collect(Collectors.toMap(Function.identity(), c -> new HashMap<>()));
+    startTime = roundDownTo5MinBoundary(startTime);
+    endTime = roundUpTo5MinBoundary(endTime);
     getTimelineObject(projectParams, monitoredServiceIdentifiers, null, changeCategories, changeSourceTypes,
         startTime.minus(Duration.between(startTime, endTime)), endTime, 2, isMonitoredServiceIdentifierScoped)
         .forEachRemaining(timelineObject -> {
@@ -359,33 +369,18 @@ public class ChangeEventServiceImpl implements ChangeEventService {
     return ((double) (current - previous) * 100) / previous;
   }
 
-  private Criteria[] getCriteriasForInfraEvents(Query<Activity> q, Instant startTime, Instant endTime,
-      ProjectParams projectParams, List<String> monitoredServiceIdentifiers, List<ChangeCategory> changeCategories,
-      List<ChangeSourceType> changeSourceTypes) {
-    List<Criteria> criterias = getCriterias(q, changeCategories, changeSourceTypes, startTime, endTime);
-    criterias.addAll(Arrays.asList(q.criteria(ActivityKeys.accountId).equal(projectParams.getAccountIdentifier()),
-        q.criteria(ActivityKeys.orgIdentifier).equal(projectParams.getOrgIdentifier()),
-        q.criteria(ActivityKeys.projectIdentifier).equal(projectParams.getProjectIdentifier()),
-        q.criteria(
-             KubernetesClusterActivityKeys.relatedAppServices + "." + ServiceEnvironmentKeys.monitoredServiceIdentifier)
-            .in(CollectionUtils.emptyIfNull(monitoredServiceIdentifiers))));
-    return criterias.toArray(new Criteria[criterias.size()]);
-  }
-
-  private Criteria[] getCriteriasForAppEvents(Query<Activity> q, Instant startTime, Instant endTime,
-      ProjectParams projectParams, List<String> monitoredServiceIdentifiers, List<ChangeCategory> changeCategories,
-      List<ChangeSourceType> changeSourceTypes) {
-    List<Criteria> criterias = getCriterias(q, changeCategories, changeSourceTypes, startTime, endTime);
-    criterias.addAll(Arrays.asList(q.criteria(ActivityKeys.accountId).equal(projectParams.getAccountIdentifier()),
-        q.criteria(ActivityKeys.orgIdentifier).equal(projectParams.getOrgIdentifier()),
-        q.criteria(ActivityKeys.projectIdentifier).equal(projectParams.getProjectIdentifier()),
-        q.criteria(ActivityKeys.monitoredServiceIdentifier)
-            .in(CollectionUtils.emptyIfNull(monitoredServiceIdentifiers))));
-    return criterias.toArray(new Criteria[criterias.size()]);
-  }
-
   private List<Criteria> getCriterias(Query<Activity> q, List<ChangeCategory> changeCategories,
       List<ChangeSourceType> changeSourceTypes, Instant startTime, Instant endTime) {
+    Stream<ChangeSourceType> changeSourceTypeStream = getChangeSourceEvent(changeCategories, changeSourceTypes);
+    return new ArrayList<>(Arrays.asList(
+        q.criteria(ActivityKeys.type)
+            .in(changeSourceTypeStream.map(ChangeSourceType::getActivityType).collect(Collectors.toList())),
+        q.criteria(ActivityKeys.eventTime).lessThan(endTime),
+        q.criteria(ActivityKeys.eventTime).greaterThanOrEq(startTime)));
+  }
+
+  private Stream<ChangeSourceType> getChangeSourceEvent(
+      List<ChangeCategory> changeCategories, List<ChangeSourceType> changeSourceTypes) {
     Stream<ChangeSourceType> changeSourceTypeStream = Arrays.stream(ChangeSourceType.values());
     if (CollectionUtils.isNotEmpty(changeCategories)) {
       changeSourceTypeStream = changeSourceTypeStream.filter(
@@ -394,11 +389,7 @@ public class ChangeEventServiceImpl implements ChangeEventService {
     if (CollectionUtils.isNotEmpty(changeSourceTypes)) {
       changeSourceTypeStream = changeSourceTypeStream.filter(changeSourceTypes::contains);
     }
-    return new ArrayList<>(Arrays.asList(
-        q.criteria(ActivityKeys.type)
-            .in(changeSourceTypeStream.map(ChangeSourceType::getActivityType).collect(Collectors.toList())),
-        q.criteria(ActivityKeys.eventTime).lessThan(endTime),
-        q.criteria(ActivityKeys.eventTime).greaterThanOrEq(startTime)));
+    return changeSourceTypeStream;
   }
 
   private Query<Activity> createQuery(Instant startTime, Instant endTime, ProjectParams projectParams,
@@ -465,6 +456,50 @@ public class ChangeEventServiceImpl implements ChangeEventService {
                       .in(monitoredServiceIdentifiers)))};
     }
   }
+
+  private Query<ActivityBucket> createQueryForActivityBucket(Instant startTime, Instant endTime,
+      ProjectParams projectParams, List<String> monitoredServiceIdentifiers, String searchText,
+      List<ChangeCategory> changeCategories, List<ChangeSourceType> changeSourceTypes,
+      boolean isMonitoredServiceIdentifierScoped) {
+    Query<ActivityBucket> query = hPersistence.createQuery(ActivityBucket.class);
+    Stream<ChangeSourceType> changeSourceTypeStream = getChangeSourceEvent(changeCategories, changeSourceTypes);
+    List<Criteria> criteria = new ArrayList<>(Arrays.asList(
+        query.criteria(ActivityBucketKeys.type)
+            .in(changeSourceTypeStream.map(ChangeSourceType::getActivityType).collect(Collectors.toList())),
+        query.criteria(ActivityBucketKeys.bucketTime).lessThan(endTime),
+        query.criteria(ActivityBucketKeys.bucketTime).greaterThanOrEq(startTime)));
+    Criteria[] criteriaForAppAndInfraEvents = getCriteriaForAppAndInfraEventsFromActivityBucket(
+        query, projectParams, monitoredServiceIdentifiers, isMonitoredServiceIdentifierScoped);
+    query.and(criteria.toArray(new Criteria[0]));
+    query.and(criteriaForAppAndInfraEvents);
+    query.useReadPreference(ReadPreference.secondaryPreferred());
+    return query;
+  }
+  private Criteria[] getCriteriaForAppAndInfraEventsFromActivityBucket(Query<?> query, ProjectParams projectParams,
+      List<String> monitoredServiceIdentifiers, boolean isMonitoredServiceIdentifierScoped) {
+    if (isMonitoredServiceIdentifierScoped) {
+      List<ResourceParams> monitoredServiceIdentifiersWithParams =
+          ScopedInformation.getResourceParamsFromScopedIdentifiers(monitoredServiceIdentifiers);
+      Criteria[] criteria = new Criteria[monitoredServiceIdentifiersWithParams.size()];
+      for (int i = 0; i < monitoredServiceIdentifiersWithParams.size(); i++) {
+        criteria[i] = query.and(query.criteria(ActivityBucketKeys.accountId)
+                                    .equal(monitoredServiceIdentifiersWithParams.get(i).getAccountIdentifier()),
+            query.criteria(ActivityBucketKeys.orgIdentifier)
+                .equal(monitoredServiceIdentifiersWithParams.get(i).getOrgIdentifier()),
+            query.criteria(ActivityBucketKeys.projectIdentifier)
+                .equal(monitoredServiceIdentifiersWithParams.get(i).getProjectIdentifier()),
+            query.criteria(ActivityBucketKeys.monitoredServiceIdentifiers)
+                .equal(monitoredServiceIdentifiersWithParams.get(i).getIdentifier()));
+      }
+      return new Criteria[] {query.or(criteria)};
+    } else {
+      return new Criteria[] {
+          query.and(query.criteria(ActivityBucketKeys.accountId).equal(projectParams.getAccountIdentifier()),
+              query.criteria(ActivityBucketKeys.orgIdentifier).equal(projectParams.getOrgIdentifier()),
+              query.criteria(ActivityBucketKeys.projectIdentifier).equal(projectParams.getProjectIdentifier()),
+              query.criteria(ActivityBucketKeys.monitoredServiceIdentifiers).in(monitoredServiceIdentifiers))};
+    }
+  }
   @VisibleForTesting
   Query<Activity> createTextSearchQuery(Instant startTime, Instant endTime, String searchText,
       List<ChangeCategory> changeCategories, List<ChangeSourceType> changeSourceTypes) {
@@ -475,16 +510,6 @@ public class ChangeEventServiceImpl implements ChangeEventService {
                                 .field(ActivityKeys.eventTime)
                                 .greaterThanOrEq(startTime)
                                 .disableValidation();
-    Stream<ChangeSourceType> changeSourceTypeStream = Arrays.stream(ChangeSourceType.values());
-    if (CollectionUtils.isNotEmpty(changeCategories)) {
-      changeSourceTypeStream = changeSourceTypeStream.filter(
-          changeSourceType -> changeCategories.contains(changeSourceType.getChangeCategory()));
-    }
-    if (CollectionUtils.isNotEmpty(changeSourceTypes)) {
-      changeSourceTypeStream = changeSourceTypeStream.filter(changeSourceTypes::contains);
-    }
-    query = query.field(ActivityKeys.type)
-                .in(changeSourceTypeStream.map(ChangeSourceType::getActivityType).collect(Collectors.toList()));
     return query;
   }
 

--- a/srm-service/modules/cv-nextgen-service/service/src/main/java/io/harness/cvng/core/transformer/changeEvent/ChangeEventMetaDataTransformer.java
+++ b/srm-service/modules/cv-nextgen-service/service/src/main/java/io/harness/cvng/core/transformer/changeEvent/ChangeEventMetaDataTransformer.java
@@ -68,14 +68,14 @@ public abstract class ChangeEventMetaDataTransformer<E extends Activity, M exten
   public final ActivityBucket getActivityBucket(E activity) {
     Instant eventTime =
         Objects.isNull(activity.getEventTime()) ? activity.getActivityStartTime() : activity.getEventTime();
-    ActivityBucket activityBucket = ActivityBucket.builder()
-                                        .accountId(activity.getAccountId())
-                                        .orgIdentifier(activity.getOrgIdentifier())
-                                        .projectIdentifier(activity.getProjectIdentifier())
-                                        .monitoredServiceIdentifiers(getMonitoredServiceIdentifiers(activity))
-                                        .bucketTime(DateTimeUtils.roundDownTo5MinBoundary(eventTime))
-                                        .build();
-    return activityBucket;
+    return ActivityBucket.builder()
+        .accountId(activity.getAccountId())
+        .orgIdentifier(activity.getOrgIdentifier())
+        .projectIdentifier(activity.getProjectIdentifier())
+        .monitoredServiceIdentifiers(getMonitoredServiceIdentifiers(activity))
+        .bucketTime(DateTimeUtils.roundDownTo5MinBoundary(eventTime))
+        .type(activity.getType())
+        .build();
   }
   protected List<String> getMonitoredServiceIdentifiers(E activity) {
     return Collections.singletonList(activity.getMonitoredServiceIdentifier());

--- a/srm-service/modules/cv-nextgen-service/service/src/main/java/io/harness/cvng/core/transformer/changeEvent/KubernetesClusterChangeEventMetadataTransformer.java
+++ b/srm-service/modules/cv-nextgen-service/service/src/main/java/io/harness/cvng/core/transformer/changeEvent/KubernetesClusterChangeEventMetadataTransformer.java
@@ -12,6 +12,7 @@ import io.harness.cvng.beans.change.ChangeEventDTO;
 import io.harness.cvng.beans.change.KubernetesChangeEventMetadata;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 
 public class KubernetesClusterChangeEventMetadataTransformer
@@ -61,6 +62,9 @@ public class KubernetesClusterChangeEventMetadataTransformer
 
   @Override
   public List<String> getMonitoredServiceIdentifiers(KubernetesClusterActivity activity) {
-    return activity.getRealatedAppMonitoredServiceIdentifiers();
+    List<String> monitoredServiceIdentifiers = new ArrayList<>();
+    monitoredServiceIdentifiers.add(activity.getMonitoredServiceIdentifier());
+    monitoredServiceIdentifiers.addAll(activity.getRealatedAppMonitoredServiceIdentifiers());
+    return monitoredServiceIdentifiers;
   }
 }

--- a/srm-service/modules/cv-nextgen-service/service/src/main/java/io/harness/cvng/core/utils/DateTimeUtils.java
+++ b/srm-service/modules/cv-nextgen-service/service/src/main/java/io/harness/cvng/core/utils/DateTimeUtils.java
@@ -34,6 +34,22 @@ public class DateTimeUtils {
     return zonedDateTime.toInstant();
   }
 
+  public static Instant roundUpTo5MinBoundary(Instant instant) {
+    return roundUpToMinBoundary(instant, 5);
+  }
+
+  public static Instant roundUpToMinBoundary(Instant instant, int minBoundary) {
+    Preconditions.checkArgument(minBoundary > 0 && minBoundary < 60, "Minute boundary need to be between 1 to 59");
+    ZonedDateTime zonedDateTime = instant.atZone(ZoneOffset.UTC);
+    int minute = zonedDateTime.getMinute();
+    if (minute % minBoundary != 0) {
+      minute = minute + (minBoundary - minute % minBoundary);
+    }
+    zonedDateTime = ZonedDateTime.of(zonedDateTime.getYear(), zonedDateTime.getMonthValue(),
+        zonedDateTime.getDayOfMonth(), zonedDateTime.getHour(), minute, 0, 0, ZoneOffset.UTC);
+    return zonedDateTime.toInstant();
+  }
+
   public static long instantToEpochMinute(Instant instant) {
     return TimeUnit.MILLISECONDS.toMinutes(instant.toEpochMilli());
   }

--- a/srm-service/modules/cv-nextgen-service/service/src/main/java/io/harness/cvng/migration/CVNGBackgroundMigrationList.java
+++ b/srm-service/modules/cv-nextgen-service/service/src/main/java/io/harness/cvng/migration/CVNGBackgroundMigrationList.java
@@ -9,6 +9,7 @@ package io.harness.cvng.migration;
 
 import io.harness.annotations.dev.HarnessTeam;
 import io.harness.annotations.dev.OwnedBy;
+import io.harness.cvng.migration.list.ActivityBucketCleanupAndMigration;
 import io.harness.cvng.migration.list.ActivityCleanupAndBucketMigration;
 import io.harness.cvng.migration.list.AddDeploymentMonitoringSourcePerpetualTask;
 import io.harness.cvng.migration.list.AddEnabledFlagToSLISLOMigration;
@@ -140,6 +141,7 @@ public class CVNGBackgroundMigrationList {
         .add(Pair.of(62, OrphanMonitoredServicesCleanup.class))
         .add(Pair.of(63, ActivityCleanupAndBucketMigration.class))
         .add(Pair.of(64, UpdateMSNotificationChangeCategoriesMigration.class))
+        .add(Pair.of(65, ActivityBucketCleanupAndMigration.class))
         .build();
   }
 }

--- a/srm-service/modules/cv-nextgen-service/service/src/main/java/io/harness/cvng/migration/list/ActivityBucketCleanupAndMigration.java
+++ b/srm-service/modules/cv-nextgen-service/service/src/main/java/io/harness/cvng/migration/list/ActivityBucketCleanupAndMigration.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 Harness Inc. All rights reserved.
+ * Use of this source code is governed by the PolyForm Free Trial 1.0.0 license
+ * that can be found in the licenses directory at the root of this repository, also available at
+ * https://polyformproject.org/wp-content/uploads/2020/05/PolyForm-Free-Trial-1.0.0.txt.
+ */
+
+package io.harness.cvng.migration.list;
+
+import io.harness.cvng.activity.entities.Activity;
+import io.harness.cvng.activity.entities.ActivityBucket;
+import io.harness.cvng.activity.services.api.ActivityService;
+import io.harness.persistence.HIterator;
+import io.harness.persistence.HPersistence;
+import io.harness.persistence.UuidAware;
+
+import com.google.inject.Inject;
+import dev.morphia.query.FindOptions;
+import dev.morphia.query.Query;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ActivityBucketCleanupAndMigration extends CVNGBaseMigration {
+  @Inject private HPersistence hPersistence;
+  @Inject ActivityService activityService;
+
+  @Override
+  public void migrate() {
+    log.info("Starting cleanup for older activities and creating bucket for newer activities");
+    Query<ActivityBucket> queryToDeleteOlderRecords =
+        hPersistence.createQuery(ActivityBucket.class).project(UuidAware.UUID_KEY, true);
+    while (true) {
+      List<ActivityBucket> recordsToBeDeleted = queryToDeleteOlderRecords.find(new FindOptions().limit(1000)).toList();
+      List<String> uuidsToBeDeleted =
+          recordsToBeDeleted.stream().map(ActivityBucket::getUuid).collect(Collectors.toList());
+      if (uuidsToBeDeleted.size() == 0) {
+        break;
+      }
+      hPersistence.delete(
+          hPersistence.createQuery(ActivityBucket.class).field(UuidAware.UUID_KEY).in(uuidsToBeDeleted));
+    }
+
+    Query<Activity> queryToAddToBucket = hPersistence.createQuery(Activity.class);
+    try (HIterator<Activity> iterator = new HIterator<>(queryToAddToBucket.fetch())) {
+      while (iterator.hasNext()) {
+        try {
+          Activity activity = iterator.next();
+          activityService.saveActivityBucket(activity);
+        } catch (Exception ex) {
+          log.error("Exception while creating bucket for newer activities", ex);
+        }
+      }
+    } catch (Exception ex) {
+      log.error("Exception while creating bucket for newer activities", ex);
+    }
+  }
+}

--- a/srm-service/modules/cv-nextgen-service/service/src/test/java/io/harness/cvng/BuilderFactory.java
+++ b/srm-service/modules/cv-nextgen-service/service/src/test/java/io/harness/cvng/BuilderFactory.java
@@ -1054,7 +1054,7 @@ public class BuilderFactory {
         .deploymentTag("deploymentTag")
         .stageId("stageId")
         .pipelineId("pipelineId")
-        .planExecutionId("executionId")
+        .planExecutionId(generateUuid())
         .artifactType("artifactType")
         .artifactTag("artifactTag")
         .activityName(generateUuid())
@@ -1107,6 +1107,8 @@ public class BuilderFactory {
                     DeepLink.builder().action(DeepLink.Action.REDIRECT_URL).url("internalUrl").build())
                 .eventDescriptions(Arrays.asList("eventDesc1", "eventDesc2"))
                 .build())
+        .activityStartTime(clock.instant())
+        .activityEndTime(clock.instant())
         .eventEndTime(clock.instant().toEpochMilli());
   }
 
@@ -1144,9 +1146,13 @@ public class BuilderFactory {
         .workflowEndTime(clock.instant())
         .workflowStartTime(clock.instant())
         .workflowId("workflowId")
-        .workflowExecutionId("workflowExecutionId")
+        .workflowExecutionId(generateUuid())
         .activityName(generateUuid())
         .activityEndTime(clock.instant())
+        .appId(generateUuid())
+        .serviceId(generateUuid())
+        .environmentId(generateUuid())
+        .name(generateUuid())
         .activityStartTime(clock.instant());
   }
 
@@ -1180,6 +1186,9 @@ public class BuilderFactory {
         .pagerDutyUrl("https://myurl.com/pagerduty/token")
         .eventId("eventId")
         .activityName("New pager duty incident")
+        .status(generateUuid())
+        .htmlUrl(generateUuid())
+        .pagerDutyUrl(generateUuid())
         .activityStartTime(clock.instant());
   }
 
@@ -1194,6 +1203,8 @@ public class BuilderFactory {
         .type(ChangeSourceType.KUBERNETES.getActivityType())
         .activityStartTime(clock.instant())
         .activityName("K8 Activity")
+        .resourceType(KubernetesResourceType.ConfigMap)
+        .action(Action.Add)
         .resourceVersion("resource-version")
         .relatedAppServices(Arrays.asList(
             RelatedAppMonitoredService.builder().monitoredServiceIdentifier("dependent_service").build()));

--- a/srm-service/modules/cv-nextgen-service/service/src/test/java/io/harness/cvng/activity/services/impl/ActivityServiceImplTest.java
+++ b/srm-service/modules/cv-nextgen-service/service/src/test/java/io/harness/cvng/activity/services/impl/ActivityServiceImplTest.java
@@ -206,8 +206,10 @@ public class ActivityServiceImplTest extends CvNextGenTestBase {
   @Category(UnitTests.class)
   public void testUpsert_updateEntity() {
     useMockedPersistentLocker();
-    Activity existingActivity = builderFactory.getDeploymentActivityBuilder().build();
-    Activity updatingActivity = builderFactory.getDeploymentActivityBuilder().build();
+    Activity existingActivity =
+        builderFactory.getDeploymentActivityBuilder().planExecutionId("planExecutionId").build();
+    Activity updatingActivity =
+        builderFactory.getDeploymentActivityBuilder().planExecutionId("planExecutionId").build();
     List<String> verificationJobInstanceIds = new ArrayList<>();
     verificationJobInstanceIds.addAll(existingActivity.getVerificationJobInstanceIds());
     verificationJobInstanceIds.addAll(updatingActivity.getVerificationJobInstanceIds());

--- a/srm-service/modules/cv-nextgen-service/service/src/test/java/io/harness/cvng/core/services/impl/ChangeEventServiceImplTest.java
+++ b/srm-service/modules/cv-nextgen-service/service/src/test/java/io/harness/cvng/core/services/impl/ChangeEventServiceImplTest.java
@@ -24,6 +24,7 @@ import io.harness.CvNextGenTestBase;
 import io.harness.category.element.UnitTests;
 import io.harness.cvng.BuilderFactory;
 import io.harness.cvng.activity.entities.Activity;
+import io.harness.cvng.activity.services.api.ActivityService;
 import io.harness.cvng.beans.activity.ActivityType;
 import io.harness.cvng.beans.change.ChangeCategory;
 import io.harness.cvng.beans.change.ChangeEventDTO;
@@ -65,6 +66,7 @@ import org.mockito.MockitoAnnotations;
 
 public class ChangeEventServiceImplTest extends CvNextGenTestBase {
   @Inject MonitoredServiceService monitoredServiceService;
+  @Inject ActivityService activityService;
   @Inject ChangeEventServiceImpl changeEventService;
   @Inject ChangeSourceService changeSourceService;
   @Inject HPersistence hPersistence;
@@ -337,7 +339,7 @@ public class ChangeEventServiceImplTest extends CvNextGenTestBase {
   @Owner(developers = ABHIJITH)
   @Category(UnitTests.class)
   public void testGetPaginated_withTypeFiltering() {
-    hPersistence.save(Arrays.asList(
+    List<Activity> activityList = Arrays.asList(
         builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
         builderFactory.getKubernetesClusterActivityForAppServiceBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
         builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(100)).build(),
@@ -349,8 +351,8 @@ public class ChangeEventServiceImplTest extends CvNextGenTestBase {
         builderFactory.getPagerDutyActivityBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
         builderFactory.getKubernetesClusterActivityForAppServiceBuilder()
             .eventTime(Instant.ofEpochSecond(300))
-            .build()));
-
+            .build());
+    activityList.forEach(activity -> activityService.upsert(activity));
     PageResponse<ChangeEventDTO> firstPage =
         changeEventService.getChangeEvents(builderFactory.getContext().getProjectParams(),
             Arrays.asList(builderFactory.getContext().getServiceIdentifier()), null, null,
@@ -381,37 +383,37 @@ public class ChangeEventServiceImplTest extends CvNextGenTestBase {
 
     assertThat(activityQuery.toString())
         .isEqualTo(
-            "{ {\"$and\": [{\"$text\": {\"$search\": \"searchText\"}}, {\"eventTime\": {\"$lt\": {\"$date\": \"2023-01-31T10:00:00Z\"}}}, {\"eventTime\": {\"$gte\": {\"$date\": \"2023-01-31T00:00:00Z\"}}}, {\"type\": {\"$in\": [\"DEPLOYMENT\"]}}]}  }");
+            "{ {\"$and\": [{\"$text\": {\"$search\": \"searchText\"}}, {\"eventTime\": {\"$lt\": {\"$date\": \"2023-01-31T10:00:00Z\"}}}, {\"eventTime\": {\"$gte\": {\"$date\": \"2023-01-31T00:00:00Z\"}}}]}  }");
 
     activityQuery = changeEventService.createTextSearchQuery(
         Instant.parse("2023-01-31T00:00:00.00Z"), Instant.parse("2023-01-31T10:00:00.00Z"), "searchText", null, null);
     assertThat(activityQuery.toString())
         .isEqualTo(
-            "{ {\"$and\": [{\"$text\": {\"$search\": \"searchText\"}}, {\"eventTime\": {\"$lt\": {\"$date\": \"2023-01-31T10:00:00Z\"}}}, {\"eventTime\": {\"$gte\": {\"$date\": \"2023-01-31T00:00:00Z\"}}}, {\"type\": {\"$in\": [\"DEPLOYMENT\", \"PAGER_DUTY\", \"KUBERNETES\", \"HARNESS_CD_CURRENT_GEN\", \"FEATURE_FLAG\", \"CHAOS_EXPERIMENT\", \"CUSTOM_DEPLOY\", \"CUSTOM_INCIDENT\", \"CUSTOM_INFRA\", \"CUSTOM_FF\"]}}]}  }");
+            "{ {\"$and\": [{\"$text\": {\"$search\": \"searchText\"}}, {\"eventTime\": {\"$lt\": {\"$date\": \"2023-01-31T10:00:00Z\"}}}, {\"eventTime\": {\"$gte\": {\"$date\": \"2023-01-31T00:00:00Z\"}}}]}  }");
   }
 
   @Test
   @Owner(developers = ABHIJITH)
   @Category(UnitTests.class)
   public void testGetChangeSummary() {
-    hPersistence.save(Arrays.asList(
+    List<Activity> activityList = Arrays.asList(
         builderFactory.getInternalChangeActivity_FFBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
         builderFactory.getInternalChangeActivity_CEBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
         builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
         builderFactory.getKubernetesClusterActivityForAppServiceBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
-        builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(100)).build(),
-        builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(200)).build(),
         builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
+        builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(350)).build(),
+        builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(400)).build(),
         builderFactory.getInternalChangeActivity_CEBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
         builderFactory.getInternalChangeActivity_FFBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
         builderFactory.getInternalChangeActivity_FFBuilder().eventTime(Instant.ofEpochSecond(400)).build(),
         builderFactory.getKubernetesClusterActivityForAppServiceBuilder()
             .eventTime(Instant.ofEpochSecond(300))
-            .build()));
-
+            .build());
+    activityList.forEach(activity -> activityService.upsert(activity));
     ChangeSummaryDTO changeSummaryDTO =
         changeEventService.getChangeSummary(builderFactory.getContext().getProjectParams(), (List<String>) null, null,
-            null, null, Instant.ofEpochSecond(100), Instant.ofEpochSecond(500));
+            null, null, Instant.ofEpochSecond(300), Instant.ofEpochSecond(500));
 
     assertThat(changeSummaryDTO.getCategoryCountMap().get(ChangeCategory.DEPLOYMENT).getCount()).isEqualTo(3);
     assertThat(changeSummaryDTO.getCategoryCountMap().get(ChangeCategory.DEPLOYMENT).getCountInPrecedingWindow())
@@ -472,7 +474,7 @@ public class ChangeEventServiceImplTest extends CvNextGenTestBase {
   @Owner(developers = ABHIJITH)
   @Category(UnitTests.class)
   public void testGetChangeSummary_withServiceFiltering() {
-    hPersistence.save(Arrays.asList(
+    List<Activity> activityList = Arrays.asList(
         builderFactory.getInternalChangeActivity_FFBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
         builderFactory.getInternalChangeActivity_FFBuilder()
             .monitoredServiceIdentifier("service_env2")
@@ -485,17 +487,17 @@ public class ChangeEventServiceImplTest extends CvNextGenTestBase {
             .build(),
         builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
         builderFactory.getKubernetesClusterActivityForAppServiceBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
-        builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(100)).build(),
+        builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
         builderFactory.getDeploymentActivityBuilder()
             .monitoredServiceIdentifier("service_env2")
             .eventTime(Instant.ofEpochSecond(200))
             .build(),
-        builderFactory.getInternalChangeActivity_FFBuilder().eventTime(Instant.ofEpochSecond(250)).build(),
+        builderFactory.getInternalChangeActivity_FFBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
         builderFactory.getInternalChangeActivity_FFBuilder()
             .monitoredServiceIdentifier("service_env2")
             .eventTime(Instant.ofEpochSecond(250))
             .build(),
-        builderFactory.getInternalChangeActivity_CEBuilder().eventTime(Instant.ofEpochSecond(250)).build(),
+        builderFactory.getInternalChangeActivity_CEBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
         builderFactory.getInternalChangeActivity_CEBuilder()
             .monitoredServiceIdentifier("service_env2")
             .eventTime(Instant.ofEpochSecond(250))
@@ -503,12 +505,12 @@ public class ChangeEventServiceImplTest extends CvNextGenTestBase {
         builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
         builderFactory.getKubernetesClusterActivityForAppServiceBuilder()
             .eventTime(Instant.ofEpochSecond(300))
-            .build()));
-
+            .build());
+    activityList.forEach(activity -> activityService.upsert(activity));
     ChangeSummaryDTO changeSummaryDTO =
         changeEventService.getChangeSummary(builderFactory.getContext().getProjectParams(),
             Arrays.asList(builderFactory.getContext().getServiceIdentifier()), null, null, null,
-            Instant.ofEpochSecond(100), Instant.ofEpochSecond(500));
+            Instant.ofEpochSecond(300), Instant.ofEpochSecond(500));
 
     assertThat(changeSummaryDTO.getCategoryCountMap().get(ChangeCategory.DEPLOYMENT).getCount()).isEqualTo(2);
     assertThat(changeSummaryDTO.getCategoryCountMap().get(ChangeCategory.DEPLOYMENT).getCountInPrecedingWindow())
@@ -548,24 +550,24 @@ public class ChangeEventServiceImplTest extends CvNextGenTestBase {
   @Owner(developers = ABHIJITH)
   @Category(UnitTests.class)
   public void testGetChangeSummary_withTypeFiltering() {
-    hPersistence.save(Arrays.asList(
+    List<Activity> activityList = Arrays.asList(
         builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
         builderFactory.getKubernetesClusterActivityForAppServiceBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
-        builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(100)).build(),
+        builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(350)).build(),
         builderFactory.getDeploymentActivityBuilder()
             .monitoredServiceIdentifier("service2_env2")
-            .eventTime(Instant.ofEpochSecond(200))
+            .eventTime(Instant.ofEpochSecond(350))
             .build(),
-        builderFactory.getPagerDutyActivityBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
+        builderFactory.getPagerDutyActivityBuilder().eventTime(Instant.ofEpochSecond(350)).build(),
         builderFactory.getKubernetesClusterActivityForAppServiceBuilder()
-            .eventTime(Instant.ofEpochSecond(300))
-            .build()));
-
+            .eventTime(Instant.ofEpochSecond(350))
+            .build());
+    activityList.forEach(activity -> activityService.upsert(activity));
     ChangeSummaryDTO changeSummaryDTO =
         changeEventService.getChangeSummary(builderFactory.getContext().getProjectParams(),
             Arrays.asList(builderFactory.getContext().getServiceIdentifier()), null,
             Arrays.asList(ChangeCategory.DEPLOYMENT, ChangeCategory.ALERTS),
-            Arrays.asList(ChangeSourceType.HARNESS_CD, ChangeSourceType.KUBERNETES), Instant.ofEpochSecond(100),
+            Arrays.asList(ChangeSourceType.HARNESS_CD, ChangeSourceType.KUBERNETES), Instant.ofEpochSecond(300),
             Instant.ofEpochSecond(500));
 
     assertThat(changeSummaryDTO.getCategoryCountMap().get(ChangeCategory.DEPLOYMENT).getCount()).isEqualTo(1);
@@ -583,45 +585,38 @@ public class ChangeEventServiceImplTest extends CvNextGenTestBase {
   @Owner(developers = ARPITJ)
   @Category(UnitTests.class)
   public void testGetChangeSummary_withTypeFilteringInternalChangeSource() {
-    hPersistence.save(Arrays.asList(
-        builderFactory.getInternalChangeActivity_FFBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
-        builderFactory.getInternalChangeActivity_FFBuilder()
-            .monitoredServiceIdentifier("service_env2")
-            .eventTime(Instant.ofEpochSecond(50))
-            .build(),
-        builderFactory.getInternalChangeActivity_CEBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
-        builderFactory.getInternalChangeActivity_CEBuilder()
-            .monitoredServiceIdentifier("service_env2")
-            .eventTime(Instant.ofEpochSecond(50))
-            .build(),
-        builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
-        builderFactory.getKubernetesClusterActivityForAppServiceBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
-        builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(100)).build(),
-        builderFactory.getDeploymentActivityBuilder()
-            .monitoredServiceIdentifier("service2_env2")
-            .eventTime(Instant.ofEpochSecond(200))
-            .build(),
-        builderFactory.getInternalChangeActivity_FFBuilder().eventTime(Instant.ofEpochSecond(250)).build(),
-        builderFactory.getInternalChangeActivity_FFBuilder()
-            .monitoredServiceIdentifier("service_env2")
-            .eventTime(Instant.ofEpochSecond(250))
-            .build(),
-        builderFactory.getInternalChangeActivity_CEBuilder().eventTime(Instant.ofEpochSecond(250)).build(),
-        builderFactory.getInternalChangeActivity_CEBuilder()
-            .monitoredServiceIdentifier("service_env2")
-            .eventTime(Instant.ofEpochSecond(250))
-            .build(),
-        builderFactory.getPagerDutyActivityBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
-        builderFactory.getKubernetesClusterActivityForAppServiceBuilder()
-            .eventTime(Instant.ofEpochSecond(300))
-            .build()));
-
+    List<Activity> activities =
+        Arrays.asList(builderFactory.getInternalChangeActivity_FFBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
+            builderFactory.getInternalChangeActivity_FFBuilder()
+                .monitoredServiceIdentifier("service_env2")
+                .eventTime(Instant.ofEpochSecond(50))
+                .build(),
+            builderFactory.getInternalChangeActivity_CEBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
+            builderFactory.getInternalChangeActivity_CEBuilder()
+                .monitoredServiceIdentifier("service_env2")
+                .eventTime(Instant.ofEpochSecond(50))
+                .build(),
+            builderFactory.getInternalChangeActivity_FFBuilder().eventTime(Instant.ofEpochSecond(350)).build(),
+            builderFactory.getInternalChangeActivity_FFBuilder()
+                .monitoredServiceIdentifier("service_env2")
+                .eventTime(Instant.ofEpochSecond(350))
+                .build(),
+            builderFactory.getInternalChangeActivity_CEBuilder().eventTime(Instant.ofEpochSecond(350)).build(),
+            builderFactory.getInternalChangeActivity_CEBuilder()
+                .monitoredServiceIdentifier("service_env2")
+                .eventTime(Instant.ofEpochSecond(350))
+                .build(),
+            builderFactory.getPagerDutyActivityBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
+            builderFactory.getKubernetesClusterActivityForAppServiceBuilder()
+                .eventTime(Instant.ofEpochSecond(300))
+                .build());
+    activities.forEach(activity -> activityService.upsert(activity));
     ChangeSummaryDTO changeSummaryDTO =
         changeEventService.getChangeSummary(builderFactory.getContext().getProjectParams(),
             Arrays.asList(builderFactory.getContext().getServiceIdentifier()), null,
             Arrays.asList(ChangeCategory.DEPLOYMENT, ChangeCategory.FEATURE_FLAG, ChangeCategory.CHAOS_EXPERIMENT),
             Arrays.asList(ChangeSourceType.HARNESS_FF, ChangeSourceType.KUBERNETES, ChangeSourceType.HARNESS_CE),
-            Instant.ofEpochSecond(100), Instant.ofEpochSecond(500));
+            Instant.ofEpochSecond(300), Instant.ofEpochSecond(500));
 
     assertThat(changeSummaryDTO.getCategoryCountMap().get(ChangeCategory.DEPLOYMENT).getCount()).isEqualTo(0);
     assertThat(changeSummaryDTO.getCategoryCountMap().get(ChangeCategory.DEPLOYMENT).getCountInPrecedingWindow())
@@ -644,7 +639,7 @@ public class ChangeEventServiceImplTest extends CvNextGenTestBase {
   @Owner(developers = ABHIJITH)
   @Category(UnitTests.class)
   public void testGetChangeSummary_withEnvironmentFiltering() {
-    hPersistence.save(Arrays.asList(
+    List<Activity> activityList = Arrays.asList(
         builderFactory.getInternalChangeActivity_FFBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
         builderFactory.getInternalChangeActivity_FFBuilder()
             .monitoredServiceIdentifier("service_env2")
@@ -657,29 +652,29 @@ public class ChangeEventServiceImplTest extends CvNextGenTestBase {
             .build(),
         builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
         builderFactory.getKubernetesClusterActivityForAppServiceBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
-        builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(100)).build(),
         builderFactory.getDeploymentActivityBuilder()
             .monitoredServiceIdentifier("service_env2")
             .eventTime(Instant.ofEpochSecond(200))
             .build(),
-        builderFactory.getInternalChangeActivity_FFBuilder().eventTime(Instant.ofEpochSecond(250)).build(),
+        builderFactory.getInternalChangeActivity_FFBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
         builderFactory.getInternalChangeActivity_FFBuilder()
             .monitoredServiceIdentifier("service_env2")
             .eventTime(Instant.ofEpochSecond(250))
             .build(),
-        builderFactory.getInternalChangeActivity_CEBuilder().eventTime(Instant.ofEpochSecond(250)).build(),
+        builderFactory.getInternalChangeActivity_CEBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
         builderFactory.getInternalChangeActivity_CEBuilder()
             .monitoredServiceIdentifier("service_env2")
             .eventTime(Instant.ofEpochSecond(250))
             .build(),
         builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
+        builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(350)).build(),
         builderFactory.getKubernetesClusterActivityForAppServiceBuilder()
             .eventTime(Instant.ofEpochSecond(300))
-            .build()));
-
+            .build());
+    activityList.forEach(activity -> activityService.upsert(activity));
     ChangeSummaryDTO changeSummaryDTO =
         changeEventService.getChangeSummary(builderFactory.getContext().getProjectParams(), (List<String>) null,
-            Arrays.asList(builderFactory.getContext().getEnvIdentifier()), null, null, Instant.ofEpochSecond(100),
+            Arrays.asList(builderFactory.getContext().getEnvIdentifier()), null, null, Instant.ofEpochSecond(300),
             Instant.ofEpochSecond(500));
 
     assertThat(changeSummaryDTO.getCategoryCountMap().get(ChangeCategory.DEPLOYMENT).getCount()).isEqualTo(2);
@@ -709,58 +704,56 @@ public class ChangeEventServiceImplTest extends CvNextGenTestBase {
   @Owner(developers = ABHIJITH)
   @Category(UnitTests.class)
   public void testGetTimeline() {
-    hPersistence.save(Arrays.asList(
-        builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
-        builderFactory.getInternalChangeActivity_FFBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
-        builderFactory.getInternalChangeActivity_CEBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
-        builderFactory.getKubernetesClusterActivityForAppServiceBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
-        builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(100)).build(),
-        builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(200)).build(),
-        builderFactory.getInternalChangeActivity_FFBuilder().eventTime(Instant.ofEpochSecond(250)).build(),
-        builderFactory.getInternalChangeActivity_FFBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
-        builderFactory.getInternalChangeActivity_CEBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
-        builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
-        builderFactory.getKubernetesClusterActivityForAppServiceBuilder()
-            .eventTime(Instant.ofEpochSecond(300))
-            .build()));
+    List<Activity> activityList =
+        Arrays.asList(builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
+            builderFactory.getInternalChangeActivity_FFBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
+            builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(200)).build(),
+            builderFactory.getInternalChangeActivity_FFBuilder().eventTime(Instant.ofEpochSecond(250)).build(),
+            builderFactory.getInternalChangeActivity_FFBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
+            builderFactory.getInternalChangeActivity_CEBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
+            builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
+            builderFactory.getKubernetesClusterActivityForAppServiceBuilder()
+                .eventTime(Instant.ofEpochSecond(300))
+                .build());
+    activityList.forEach(activity -> activityService.upsert(activity));
     ChangeTimeline changeTimeline = changeEventService.getTimeline(builderFactory.getContext().getProjectParams(), null,
         null, null, false, null, null, null, Instant.ofEpochSecond(100), Instant.ofEpochSecond(500), 2);
 
     List<TimeRangeDetail> deploymentChanges = changeTimeline.getCategoryTimeline().get(ChangeCategory.DEPLOYMENT);
     assertThat(deploymentChanges.size()).isEqualTo(2);
     assertThat(deploymentChanges.get(0).getCount()).isEqualTo(2);
-    assertThat(deploymentChanges.get(0).getStartTime()).isEqualTo(100000);
+    assertThat(deploymentChanges.get(0).getStartTime()).isEqualTo(0);
     assertThat(deploymentChanges.get(0).getEndTime()).isEqualTo(300000);
     assertThat(deploymentChanges.get(1).getCount()).isEqualTo(1);
     assertThat(deploymentChanges.get(1).getStartTime()).isEqualTo(300000);
-    assertThat(deploymentChanges.get(1).getEndTime()).isEqualTo(500000);
+    assertThat(deploymentChanges.get(1).getEndTime()).isEqualTo(600000);
     List<TimeRangeDetail> infrastructureChanges =
         changeTimeline.getCategoryTimeline().get(ChangeCategory.INFRASTRUCTURE);
     assertThat(infrastructureChanges.size()).isEqualTo(1);
     assertThat(infrastructureChanges.get(0).getCount()).isEqualTo(1);
     assertThat(infrastructureChanges.get(0).getStartTime()).isEqualTo(300000);
-    assertThat(infrastructureChanges.get(0).getEndTime()).isEqualTo(500000);
+    assertThat(infrastructureChanges.get(0).getEndTime()).isEqualTo(600000);
     List<TimeRangeDetail> featureFlagChanges = changeTimeline.getCategoryTimeline().get(ChangeCategory.FEATURE_FLAG);
     assertThat(featureFlagChanges.size()).isEqualTo(2);
-    assertThat(featureFlagChanges.get(0).getCount()).isEqualTo(1);
-    assertThat(featureFlagChanges.get(0).getStartTime()).isEqualTo(100000);
+    assertThat(featureFlagChanges.get(0).getCount()).isEqualTo(2);
+    assertThat(featureFlagChanges.get(0).getStartTime()).isEqualTo(0);
     assertThat(featureFlagChanges.get(0).getEndTime()).isEqualTo(300000);
     assertThat(featureFlagChanges.get(1).getCount()).isEqualTo(1);
     assertThat(featureFlagChanges.get(1).getStartTime()).isEqualTo(300000);
-    assertThat(featureFlagChanges.get(1).getEndTime()).isEqualTo(500000);
+    assertThat(featureFlagChanges.get(1).getEndTime()).isEqualTo(600000);
     List<TimeRangeDetail> chaosExperimentChanges =
         changeTimeline.getCategoryTimeline().get(ChangeCategory.CHAOS_EXPERIMENT);
     assertThat(chaosExperimentChanges.size()).isEqualTo(1);
     assertThat(chaosExperimentChanges.get(0).getCount()).isEqualTo(1);
     assertThat(chaosExperimentChanges.get(0).getStartTime()).isEqualTo(300000);
-    assertThat(chaosExperimentChanges.get(0).getEndTime()).isEqualTo(500000);
+    assertThat(chaosExperimentChanges.get(0).getEndTime()).isEqualTo(600000);
   }
 
   @Test
   @Owner(developers = ABHIJITH)
   @Category(UnitTests.class)
   public void testGetMonitoredServiceChangeTimeline() {
-    hPersistence.save(Arrays.asList(
+    List<Activity> activityList = Arrays.asList(
         builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
         builderFactory.getKubernetesClusterActivityForAppServiceBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
         builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(100)).build(),
@@ -771,7 +764,8 @@ public class ChangeEventServiceImplTest extends CvNextGenTestBase {
         builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(14398)).build(),
         builderFactory.getKubernetesClusterActivityForAppServiceBuilder()
             .eventTime(Instant.ofEpochSecond(14399500))
-            .build()));
+            .build());
+    activityList.forEach(activity -> activityService.upsert(activity));
     ChangeTimeline changeTimeline =
         changeEventService.getMonitoredServiceChangeTimeline(builderFactory.getContext().getMonitoredServiceParams(),
             null, null, DurationDTO.FOUR_HOURS, Instant.ofEpochSecond(14398));
@@ -796,16 +790,16 @@ public class ChangeEventServiceImplTest extends CvNextGenTestBase {
   @Owner(developers = ABHIJITH)
   @Category(UnitTests.class)
   public void testGetTimeline_withTypeFilters() {
-    hPersistence.save(Arrays.asList(
+    List<Activity> activityList = Arrays.asList(
         builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
         builderFactory.getKubernetesClusterActivityForAppServiceBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
         builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(100)).build(),
-        builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(200)).build(),
         builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
         builderFactory.getPagerDutyActivityBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
         builderFactory.getKubernetesClusterActivityForAppServiceBuilder()
             .eventTime(Instant.ofEpochSecond(300))
-            .build()));
+            .build());
+    activityList.forEach(activity -> activityService.upsert(activity));
     ChangeTimeline changeTimeline = changeEventService.getTimeline(builderFactory.getContext().getProjectParams(), null,
         null, null, false, null, Arrays.asList(ChangeCategory.DEPLOYMENT, ChangeCategory.ALERTS),
         Arrays.asList(ChangeSourceType.HARNESS_CD, ChangeSourceType.KUBERNETES), Instant.ofEpochSecond(100),
@@ -814,11 +808,11 @@ public class ChangeEventServiceImplTest extends CvNextGenTestBase {
     List<TimeRangeDetail> deploymentChanges = changeTimeline.getCategoryTimeline().get(ChangeCategory.DEPLOYMENT);
     assertThat(deploymentChanges.size()).isEqualTo(2);
     assertThat(deploymentChanges.get(0).getCount()).isEqualTo(2);
-    assertThat(deploymentChanges.get(0).getStartTime()).isEqualTo(100000);
+    assertThat(deploymentChanges.get(0).getStartTime()).isEqualTo(0);
     assertThat(deploymentChanges.get(0).getEndTime()).isEqualTo(300000);
     assertThat(deploymentChanges.get(1).getCount()).isEqualTo(1);
     assertThat(deploymentChanges.get(1).getStartTime()).isEqualTo(300000);
-    assertThat(deploymentChanges.get(1).getEndTime()).isEqualTo(500000);
+    assertThat(deploymentChanges.get(1).getEndTime()).isEqualTo(600000);
     List<TimeRangeDetail> infrastructureChanges =
         changeTimeline.getCategoryTimeline().get(ChangeCategory.INFRASTRUCTURE);
     assertThat(infrastructureChanges).isEmpty();
@@ -830,22 +824,21 @@ public class ChangeEventServiceImplTest extends CvNextGenTestBase {
   @Owner(developers = ABHIJITH)
   @Category(UnitTests.class)
   public void testGetTimelineObject_forAggregationValidation() {
-    hPersistence.save(Arrays.asList(
+    List<Activity> activityList = Arrays.asList(
         builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
-        builderFactory.getKubernetesClusterActivityForAppServiceBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
-        builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(100)).build(),
         builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(200)).build(),
         builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
-        builderFactory.getKubernetesClusterActivityForAppServiceBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
+        builderFactory.getKubernetesClusterActivityForAppServiceBuilder().eventTime(Instant.ofEpochSecond(350)).build(),
         builderFactory.getKubernetesClusterActivityForAppServiceBuilder()
             .eventTime(Instant.ofEpochSecond(600))
-            .build()));
-
+            .build());
+    activityList.forEach(activity -> activityService.upsert(activity));
     Iterator<TimelineObject> changeTimelineObject =
         changeEventService.getTimelineObject(builderFactory.getContext().getProjectParams(), null, null, null, null,
-            null, Instant.ofEpochSecond(100), Instant.ofEpochSecond(500), 2, false);
+            null, Instant.ofEpochSecond(0), Instant.ofEpochSecond(600), 2, false);
     List<TimelineObject> timelineObjectList = new ArrayList<>();
-    changeTimelineObject.forEachRemaining(timelineObject -> timelineObjectList.add(timelineObject));
+
+    changeTimelineObject.forEachRemaining(timelineObjectList::add);
 
     assertThat(timelineObjectList.size()).isEqualTo(3);
     assertThat(timelineObjectList.stream()
@@ -875,118 +868,123 @@ public class ChangeEventServiceImplTest extends CvNextGenTestBase {
   @Owner(developers = ABHIJITH)
   @Category(UnitTests.class)
   public void testGetTimeline_withServiceFiltering() {
-    hPersistence.save(Arrays.asList(
-        builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
-        builderFactory.getKubernetesClusterActivityForAppServiceBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
-        builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(100)).build(),
-        builderFactory.getDeploymentActivityBuilder()
-            .monitoredServiceIdentifier("monitoredservice2")
-            .eventTime(Instant.ofEpochSecond(200))
-            .build(),
-        builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
-        builderFactory.getKubernetesClusterActivityForAppServiceBuilder()
-            .eventTime(Instant.ofEpochSecond(300))
-            .build()));
+    List<Activity> activityList =
+        Arrays.asList(builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
+            builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(100)).build(),
+            builderFactory.getDeploymentActivityBuilder()
+                .monitoredServiceIdentifier("monitoredservice2")
+                .eventTime(Instant.ofEpochSecond(200))
+                .build(),
+            builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
+            builderFactory.getKubernetesClusterActivityForAppServiceBuilder()
+                .eventTime(Instant.ofEpochSecond(300))
+                .build());
+    activityList.forEach(activity -> activityService.upsert(activity));
     ChangeTimeline changeTimeline = changeEventService.getTimeline(builderFactory.getContext().getProjectParams(),
         Arrays.asList(builderFactory.getContext().getServiceIdentifier()), null, null, false, null, null, null,
         Instant.ofEpochSecond(100), Instant.ofEpochSecond(500), 2);
 
     List<TimeRangeDetail> deploymentChanges = changeTimeline.getCategoryTimeline().get(ChangeCategory.DEPLOYMENT);
     assertThat(deploymentChanges.size()).isEqualTo(2);
-    assertThat(deploymentChanges.get(0).getCount()).isEqualTo(1);
-    assertThat(deploymentChanges.get(0).getStartTime()).isEqualTo(100000);
+    assertThat(deploymentChanges.get(0).getCount()).isEqualTo(2);
+    assertThat(deploymentChanges.get(0).getStartTime()).isEqualTo(0);
     assertThat(deploymentChanges.get(0).getEndTime()).isEqualTo(300000);
     assertThat(deploymentChanges.get(1).getCount()).isEqualTo(1);
     assertThat(deploymentChanges.get(1).getStartTime()).isEqualTo(300000);
-    assertThat(deploymentChanges.get(1).getEndTime()).isEqualTo(500000);
+    assertThat(deploymentChanges.get(1).getEndTime()).isEqualTo(600000);
     List<TimeRangeDetail> infrastructureChanges =
         changeTimeline.getCategoryTimeline().get(ChangeCategory.INFRASTRUCTURE);
     assertThat(infrastructureChanges.size()).isEqualTo(1);
     assertThat(infrastructureChanges.get(0).getCount()).isEqualTo(1);
     assertThat(infrastructureChanges.get(0).getStartTime()).isEqualTo(300000);
-    assertThat(infrastructureChanges.get(0).getEndTime()).isEqualTo(500000);
+    assertThat(infrastructureChanges.get(0).getEndTime()).isEqualTo(600000);
   }
 
   @Test
   @Owner(developers = KAMAL)
   @Category(UnitTests.class)
   public void testGetTimeline_withMonitoredServiceFiltering() {
-    hPersistence.save(Arrays.asList(
-        builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
-        builderFactory.getKubernetesClusterActivityForAppServiceBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
-        builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(100)).build(),
-        builderFactory.getDeploymentActivityBuilder()
-            .monitoredServiceIdentifier("monitoredservice2")
-            .eventTime(Instant.ofEpochSecond(200))
-            .build(),
-        builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
-        builderFactory.getKubernetesClusterActivityForAppServiceBuilder()
-            .eventTime(Instant.ofEpochSecond(300))
-            .build()));
+    List<Activity> activityList =
+        Arrays.asList(builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
+            builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(100)).build(),
+            builderFactory.getDeploymentActivityBuilder()
+                .monitoredServiceIdentifier("monitoredservice2")
+                .eventTime(Instant.ofEpochSecond(200))
+                .build(),
+            builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
+            builderFactory.getKubernetesClusterActivityForAppServiceBuilder()
+                .eventTime(Instant.ofEpochSecond(300))
+                .build());
+    activityList.forEach(activity -> activityService.upsert(activity));
     ChangeTimeline changeTimeline = changeEventService.getTimeline(builderFactory.getContext().getProjectParams(), null,
         null, Arrays.asList(builderFactory.getContext().getMonitoredServiceParams().getMonitoredServiceIdentifier()),
         false, null, null, null, Instant.ofEpochSecond(100), Instant.ofEpochSecond(500), 2);
 
     List<TimeRangeDetail> deploymentChanges = changeTimeline.getCategoryTimeline().get(ChangeCategory.DEPLOYMENT);
     assertThat(deploymentChanges.size()).isEqualTo(2);
-    assertThat(deploymentChanges.get(0).getCount()).isEqualTo(1);
-    assertThat(deploymentChanges.get(0).getStartTime()).isEqualTo(100000);
+    assertThat(deploymentChanges.get(0).getCount()).isEqualTo(2);
+    assertThat(deploymentChanges.get(0).getStartTime()).isEqualTo(0);
     assertThat(deploymentChanges.get(0).getEndTime()).isEqualTo(300000);
     assertThat(deploymentChanges.get(1).getCount()).isEqualTo(1);
     assertThat(deploymentChanges.get(1).getStartTime()).isEqualTo(300000);
-    assertThat(deploymentChanges.get(1).getEndTime()).isEqualTo(500000);
+    assertThat(deploymentChanges.get(1).getEndTime()).isEqualTo(600000);
     List<TimeRangeDetail> infrastructureChanges =
         changeTimeline.getCategoryTimeline().get(ChangeCategory.INFRASTRUCTURE);
     assertThat(infrastructureChanges.size()).isEqualTo(1);
     assertThat(infrastructureChanges.get(0).getCount()).isEqualTo(1);
     assertThat(infrastructureChanges.get(0).getStartTime()).isEqualTo(300000);
-    assertThat(infrastructureChanges.get(0).getEndTime()).isEqualTo(500000);
+    assertThat(infrastructureChanges.get(0).getEndTime()).isEqualTo(600000);
   }
 
   @Test
   @Owner(developers = VARSHA_LALWANI)
   @Category(UnitTests.class)
   public void testGetTimeline_withScopedMonitoredServiceFiltering() {
-    hPersistence.save(Arrays.asList(
+    List<Activity> activityList = Arrays.asList(
         builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
         builderFactory.getKubernetesClusterActivityForAppServiceBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
-        builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(100)).build(),
         builderFactory.getDeploymentActivityBuilder()
-            .monitoredServiceIdentifier("monitoredservice2")
-            .eventTime(Instant.ofEpochSecond(200))
+            .monitoredServiceIdentifier("monitoredServiceV2")
+            .eventTime(Instant.ofEpochSecond(300))
             .build(),
-        builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
         builderFactory.getKubernetesClusterActivityForAppServiceBuilder()
             .eventTime(Instant.ofEpochSecond(300))
-            .build()));
+            .build());
+    activityList.forEach(activity -> activityService.upsert(activity));
     ChangeTimeline changeTimeline =
         changeEventService.getTimeline(builderFactory.getContext().getProjectParams(), null, null,
-            Arrays.asList(ScopedInformation.getScopedInformation(builderFactory.getContext().getAccountId(),
-                builderFactory.getContext().getOrgIdentifier(), builderFactory.getContext().getProjectIdentifier(),
-                builderFactory.getContext().getMonitoredServiceParams().getMonitoredServiceIdentifier())),
-            true, null, null, null, Instant.ofEpochSecond(100), Instant.ofEpochSecond(500), 2);
+            Arrays.asList(
+                ScopedInformation.getScopedInformation(builderFactory.getContext().getAccountId(),
+                    builderFactory.getContext().getOrgIdentifier(), builderFactory.getContext().getProjectIdentifier(),
+                    builderFactory.getContext().getMonitoredServiceParams().getMonitoredServiceIdentifier()),
+                ScopedInformation.getScopedInformation(builderFactory.getContext().getAccountId(),
+                    builderFactory.getContext().getOrgIdentifier(), builderFactory.getContext().getProjectIdentifier(),
+                    "monitoredServiceV2")),
+            true, null, null, null, Instant.ofEpochSecond(0), Instant.ofEpochSecond(600), 2);
 
     List<TimeRangeDetail> deploymentChanges = changeTimeline.getCategoryTimeline().get(ChangeCategory.DEPLOYMENT);
     assertThat(deploymentChanges.size()).isEqualTo(2);
     assertThat(deploymentChanges.get(0).getCount()).isEqualTo(1);
-    assertThat(deploymentChanges.get(0).getStartTime()).isEqualTo(100000);
+    assertThat(deploymentChanges.get(0).getStartTime()).isEqualTo(0);
     assertThat(deploymentChanges.get(0).getEndTime()).isEqualTo(300000);
     assertThat(deploymentChanges.get(1).getCount()).isEqualTo(1);
     assertThat(deploymentChanges.get(1).getStartTime()).isEqualTo(300000);
-    assertThat(deploymentChanges.get(1).getEndTime()).isEqualTo(500000);
+    assertThat(deploymentChanges.get(1).getEndTime()).isEqualTo(600000);
     List<TimeRangeDetail> infrastructureChanges =
         changeTimeline.getCategoryTimeline().get(ChangeCategory.INFRASTRUCTURE);
-    assertThat(infrastructureChanges.size()).isEqualTo(1);
     assertThat(infrastructureChanges.get(0).getCount()).isEqualTo(1);
-    assertThat(infrastructureChanges.get(0).getStartTime()).isEqualTo(300000);
-    assertThat(infrastructureChanges.get(0).getEndTime()).isEqualTo(500000);
+    assertThat(infrastructureChanges.get(0).getStartTime()).isEqualTo(0);
+    assertThat(infrastructureChanges.get(0).getEndTime()).isEqualTo(300000);
+    assertThat(infrastructureChanges.get(1).getCount()).isEqualTo(1);
+    assertThat(infrastructureChanges.get(1).getStartTime()).isEqualTo(300000);
+    assertThat(infrastructureChanges.get(1).getEndTime()).isEqualTo(600000);
   }
 
   @Test
   @Owner(developers = KAMAL)
   @Category(UnitTests.class)
   public void testGetTimeline_withMonitoredServiceAndServiceFiltering() {
-    hPersistence.save(Arrays.asList(
+    List<Activity> activityList = Arrays.asList(
         builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
         builderFactory.getKubernetesClusterActivityForAppServiceBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
         builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(100)).build(),
@@ -997,7 +995,8 @@ public class ChangeEventServiceImplTest extends CvNextGenTestBase {
         builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
         builderFactory.getKubernetesClusterActivityForAppServiceBuilder()
             .eventTime(Instant.ofEpochSecond(300))
-            .build()));
+            .build());
+    activityList.forEach(activity -> activityService.upsert(activity));
     assertThatThrownBy(
         ()
             -> changeEventService.getTimeline(builderFactory.getContext().getProjectParams(),
@@ -1012,18 +1011,17 @@ public class ChangeEventServiceImplTest extends CvNextGenTestBase {
   @Owner(developers = ABHIJITH)
   @Category(UnitTests.class)
   public void testGetTimeline_withEnvironmentFiltering() {
-    hPersistence.save(Arrays.asList(
-        builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
-        builderFactory.getKubernetesClusterActivityForAppServiceBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
-        builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(100)).build(),
-        builderFactory.getDeploymentActivityBuilder()
-            .monitoredServiceIdentifier("service2_env2")
-            .eventTime(Instant.ofEpochSecond(200))
-            .build(),
-        builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
-        builderFactory.getKubernetesClusterActivityForAppServiceBuilder()
-            .eventTime(Instant.ofEpochSecond(300))
-            .build()));
+    List<Activity> activityList =
+        Arrays.asList(builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
+            builderFactory.getDeploymentActivityBuilder()
+                .monitoredServiceIdentifier("service2_env2")
+                .eventTime(Instant.ofEpochSecond(200))
+                .build(),
+            builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(300)).build(),
+            builderFactory.getKubernetesClusterActivityForAppServiceBuilder()
+                .eventTime(Instant.ofEpochSecond(300))
+                .build());
+    activityList.forEach(activity -> activityService.upsert(activity));
     ChangeTimeline changeTimeline = changeEventService.getTimeline(builderFactory.getContext().getProjectParams(), null,
         Arrays.asList(builderFactory.getContext().getEnvIdentifier()), null, false, null, null, null,
         Instant.ofEpochSecond(100), Instant.ofEpochSecond(500), 2);
@@ -1031,25 +1029,25 @@ public class ChangeEventServiceImplTest extends CvNextGenTestBase {
     List<TimeRangeDetail> deploymentChanges = changeTimeline.getCategoryTimeline().get(ChangeCategory.DEPLOYMENT);
     assertThat(deploymentChanges.size()).isEqualTo(2);
     assertThat(deploymentChanges.get(0).getCount()).isEqualTo(1);
-    assertThat(deploymentChanges.get(0).getStartTime()).isEqualTo(100000);
+    assertThat(deploymentChanges.get(0).getStartTime()).isEqualTo(0);
     assertThat(deploymentChanges.get(0).getEndTime()).isEqualTo(300000);
     assertThat(deploymentChanges.get(1).getCount()).isEqualTo(1);
     assertThat(deploymentChanges.get(1).getStartTime()).isEqualTo(300000);
-    assertThat(deploymentChanges.get(1).getEndTime()).isEqualTo(500000);
+    assertThat(deploymentChanges.get(1).getEndTime()).isEqualTo(600000);
 
     List<TimeRangeDetail> infrastructureChanges =
         changeTimeline.getCategoryTimeline().get(ChangeCategory.INFRASTRUCTURE);
     assertThat(infrastructureChanges.size()).isEqualTo(1);
     assertThat(infrastructureChanges.get(0).getCount()).isEqualTo(1);
     assertThat(infrastructureChanges.get(0).getStartTime()).isEqualTo(300000);
-    assertThat(infrastructureChanges.get(0).getEndTime()).isEqualTo(500000);
+    assertThat(infrastructureChanges.get(0).getEndTime()).isEqualTo(600000);
   }
 
   @Test
   @Owner(developers = ABHIJITH)
   @Category(UnitTests.class)
   public void testGetPaginated_withEnvironmentFiltering() {
-    hPersistence.save(Arrays.asList(
+    List<Activity> activityList = Arrays.asList(
         builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
         builderFactory.getKubernetesClusterActivityForAppServiceBuilder().eventTime(Instant.ofEpochSecond(50)).build(),
         builderFactory.getDeploymentActivityBuilder().eventTime(Instant.ofEpochSecond(100)).build(),
@@ -1059,7 +1057,8 @@ public class ChangeEventServiceImplTest extends CvNextGenTestBase {
             .build(),
         builderFactory.getKubernetesClusterActivityForAppServiceBuilder()
             .eventTime(Instant.ofEpochSecond(300))
-            .build()));
+            .build());
+    activityList.forEach(activity -> activityService.upsert(activity));
     PageResponse<ChangeEventDTO> firstPage =
         changeEventService.getChangeEvents(builderFactory.getContext().getProjectParams(), null,
             Arrays.asList(builderFactory.getContext().getEnvIdentifier()), null, null, null, Instant.ofEpochSecond(100),
@@ -1079,10 +1078,11 @@ public class ChangeEventServiceImplTest extends CvNextGenTestBase {
   @Owner(developers = ABHIJITH)
   @Category(UnitTests.class)
   public void testGetChangeSummary_WithServiceParams() {
-    hPersistence.save(builderFactory.getDeploymentActivityBuilder().build());
-    hPersistence.save(builderFactory.getDeploymentActivityBuilder()
-                          .eventTime(builderFactory.getClock().instant().minus(Duration.ofMinutes(15)))
-                          .build());
+    List<Activity> activityList = Arrays.asList(builderFactory.getDeploymentActivityBuilder().build(),
+        builderFactory.getDeploymentActivityBuilder()
+            .eventTime(builderFactory.getClock().instant().minus(Duration.ofMinutes(15)))
+            .build());
+    activityList.forEach(activity -> activityService.upsert(activity));
     ChangeSummaryDTO changeSummaryDTO =
         changeEventService.getChangeSummary(builderFactory.getContext().getMonitoredServiceParams(),
             changeSourceIdentifiers, builderFactory.getClock().instant().minus(Duration.ofMinutes(10)),
@@ -1098,10 +1098,11 @@ public class ChangeEventServiceImplTest extends CvNextGenTestBase {
   @Owner(developers = VARSHA_LALWANI)
   @Category(UnitTests.class)
   public void testGetChangeSummary_WithMonitoredService() {
-    hPersistence.save(builderFactory.getDeploymentActivityBuilder().build());
-    hPersistence.save(builderFactory.getDeploymentActivityBuilder()
-                          .eventTime(builderFactory.getClock().instant().minus(Duration.ofMinutes(15)))
-                          .build());
+    List<Activity> activityList = Arrays.asList(builderFactory.getDeploymentActivityBuilder().build(),
+        builderFactory.getDeploymentActivityBuilder()
+            .eventTime(builderFactory.getClock().instant().minus(Duration.ofMinutes(15)))
+            .build());
+    activityList.forEach(activity -> activityService.upsert(activity));
     ChangeSummaryDTO changeSummaryDTO = changeEventService.getChangeSummary(builderFactory.getProjectParams(), null,
         Collections.singletonList(
             builderFactory.getContext().getMonitoredServiceParams().getMonitoredServiceIdentifier()),
@@ -1118,10 +1119,11 @@ public class ChangeEventServiceImplTest extends CvNextGenTestBase {
   @Owner(developers = VARSHA_LALWANI)
   @Category(UnitTests.class)
   public void testGetChangeSummary_WithScopedMonitoredService() {
-    hPersistence.save(builderFactory.getDeploymentActivityBuilder().build());
-    hPersistence.save(builderFactory.getDeploymentActivityBuilder()
-                          .eventTime(builderFactory.getClock().instant().minus(Duration.ofMinutes(15)))
-                          .build());
+    List<Activity> activityList = Arrays.asList(builderFactory.getDeploymentActivityBuilder().build(),
+        builderFactory.getDeploymentActivityBuilder()
+            .eventTime(builderFactory.getClock().instant().minus(Duration.ofMinutes(15)))
+            .build());
+    activityList.forEach(activity -> activityService.upsert(activity));
     ChangeSummaryDTO changeSummaryDTO = changeEventService.getChangeSummary(builderFactory.getProjectParams(), null,
         Collections.singletonList(ScopedInformation.getScopedInformation(builderFactory.getContext().getAccountId(),
             builderFactory.getContext().getOrgIdentifier(), builderFactory.getContext().getProjectIdentifier(),


### PR DESCRIPTION
* [techdebt]: [SRM-14680]: changing the logic for reading from activitybucket

* [techdebt]: [SRM-14680]: changing the logic for reading from activityBucket

* [techdebt]: [SRM-14680]: Fixing the migration issue in activity bucket

* [techdebt]: [SRM-14680]: Fixing the migration issue in activity bucket

* [techdebt]: [SRM-14680]: Fixing test case and scoped minitored service logic

* [techdebt]: [SRM-14680]: Fixing test case and scoped monitored service logic

* [techdebt]: [SRM-14680]: Fixing test case and scoped monitored service logic

* [techdebt]: [SRM-14680]: Fixing test case and scoped monitored service logic

* [techdebt]: [SRM-14680]: Fixing test case and scoped monitored service logic

* [techdebt]: [SRM-14680]: Fixing test case and scoped monitored service logic

* [techdebt]: [SRM-14680]: PR check fix

* [techdebt]: [SRM-14680]: PR check fix

* [techdebt]: [SRM-14680]: PR check fix